### PR TITLE
update Rakefile for the new Rubyzip interface and optionally use bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (10.1.0)
+    rubyzip (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rubyzip

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Build the packs to pkg/
 $ rake build
 ```
 
+Or if you want to use bundler
+
+```shell
+$ bundle install
+$ bundle exec rake build
+```
+
 ## License
 
 See [LICENSE.md](LICENSE.md)

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 desc "Create language packs in pkg/"
 task :build do
   require 'rubygems'
-  require 'zip/zip'
+  require 'zip'
   require 'fileutils'
 
   STDOUT.sync = true
@@ -24,7 +24,7 @@ task :build do
       FileUtils.rm_rf(pkg_path)
     end
 
-    Zip::ZipFile.open(pkg_path, Zip::ZipFile::CREATE) do |zipfile|
+    Zip::File.open(pkg_path, Zip::File::CREATE) do |zipfile|
       puts "Creating #{lang_name}..."
 
       files.each_with_index do |file, index|


### PR DESCRIPTION
Running `rake build` gives an error when using rubyzip > 1 as it has a new interface (see: https://github.com/rubyzip/rubyzip#important-note).

This PR fixes the issue. I also added a Gemfile to use with bundler. That way we can explicitly define the required gem versions if something else changes in the future.

Cheers.
