### PR TITLE
[#134] Replace `forever if` block

### DIFF
--- a/en-GB/Term 1/05 Fish Chomp/05 Fish Chomp.md
+++ b/en-GB/Term 1/05 Fish Chomp/05 Fish Chomp.md
@@ -41,9 +41,10 @@ Click the green flag.
 + You can stop the Hungry Fish flipping like crazy if you make it only move when it’s not too near the mouse pointer (The `distance to` {.blocklightblue} block is in the `Sensing` palette).
 ```blocks
     when FLAG clicked
-        forever if <(distance to [mouse-pointer v]) > (10)>
-            point towards [mouse-pointer v]
-            move (3) steps
+        forever
+            if <(distance to [mouse-pointer v]) > (10)>
+                point towards [mouse-pointer v]
+                move (3) steps
 ```
 
 ## Save your project {.save}


### PR DESCRIPTION
Fix the last remaining `forever if` block in English language lessons.

Refs #134 (I think that’s probably closable after this one).
