### PR TITLE
[Term 1 Rock Band] Fix costume reset for singer

### DIFF
--- a/en-GB/Term 1/Rock Band/Rock Band.md
+++ b/en-GB/Term 1/Rock Band/Rock Band.md
@@ -135,7 +135,7 @@ Let's add a singer to our band!
 
 	```blocks
 		when flag clicked
-		switch costume to [singing v]
+		switch costume to [not singing v]
 
 		when this sprite clicked
 		switch costume to [singing v]


### PR DESCRIPTION
Similar to the reset that applies to the drum (line 65), when clicking the flag we want all of the sprites to look like they're not doing something.
