### PR TITLE
Fix Scratch Bonus manifest errors

### DIFF
--- a/en-GB/Additional Projects/en-GB_scratch_bonus.manifest
+++ b/en-GB/Additional Projects/en-GB_scratch_bonus.manifest
@@ -12,7 +12,7 @@
             "number":   1,
             "filename": "Balloons/Balloons.md",
             "note": "Balloons/Balloons - notes.md"
-        }
+        },
         {
             "number": 2,
             "beta": true,
@@ -30,6 +30,6 @@
         {
             "number":   5,
             "filename": "Christmas Capers/Christmas Capers.md"
-        },      
+        }
     ]
 }


### PR DESCRIPTION
Scratch Bonus isn’t building at the moment, due to these typos.