### PR TITLE
Add unique IDs to vi-VN terms

### DIFF
--- a/vi-VN/Term 1/vi-VN_scratch_term1.manifest
+++ b/vi-VN/Term 1/vi-VN_scratch_term1.manifest
@@ -1,5 +1,5 @@
 {
-    "id": "scratch",
+    "id": "scratch-1",
     "title":"Beginner Scratch",
     "description":"Scratch is a simple, fun way to program by dragging and dropping blocks together",
     "language": "vi-VN",

--- a/vi-VN/Term 2/vi-VN_scratch_term2.manifest
+++ b/vi-VN/Term 2/vi-VN_scratch_term2.manifest
@@ -1,5 +1,5 @@
 {
-    "id": "scratch",
+    "id": "scratch-2",
     "title":"Advanced Scratch",
     "description":"",
     "language": "vi-VN",


### PR DESCRIPTION
Term IDs should be unique. This change ensures that’s the case for all scratch terms.

This only works at the moment because the order is included in the term folder names.