### PR TITLE
Many PDFs have broken 'when FLAG clicked' blocks; no green flag displayed.

### DIFF
--- a/en-GB/Additional Projects/Balloons/Balloons.md
+++ b/en-GB/Additional Projects/Balloons/Balloons.md
@@ -29,7 +29,7 @@ You are going to make a balloon-popping game!
 + Add this code to your balloon, so that it bounces around the screen:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		go to x:(0) y:(0)
 		point in direction (45 v)
 		forever
@@ -64,7 +64,7 @@ You are going to make a balloon-popping game!
 + Instead of using the same x and y position each time, you can let Scratch choose a random number instead. Change your balloon's code, so that it looks like this:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		go to x:(pick random (-150) to (150)) y:(pick random (-150) to (150))
 		point in direction (45 v)
 		forever
@@ -105,7 +105,7 @@ Lets allow the player to pop the balloons!
 + Make sure that your balloon switches to the right costume when the game starts. Your code should now look like this:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		switch costume to [balloon1-a v]
 		point in direction (pick random (-90) to (180))
 		go to x:(pick random (-150) to (150)) y:(pick random (-150) to (150))
@@ -134,7 +134,7 @@ Lets allow the player to pop the balloons!
 		hide
 	```
 
-+ Now that you're deleting the balloon when it's clicked, you'll also need to add a `show` {.blocklooks} block to the start of the `when flag clicked` {.blockevents} code.
++ Now that you're deleting the balloon when it's clicked, you'll also need to add a `show` {.blocklooks} block to the start of the `when FLAG clicked` {.blockevents} code.
 
 + Try popping a balloon again, to check that it works properly. If you find it difficult to pop the balloon without dragging it around, you can play the game in fullscreen mode by clicking this button:
 
@@ -162,7 +162,7 @@ Let's make things more interesting by keeping score.
 
 	![screenshot](balloons-stage-score.png)
 
-+ When a new game is started (by clicking the flag), you want to set the player's score to 0. Add this code to the top of the balloon's `when flag clicked` {.blockevents} code:
++ When a new game is started (by clicking the flag), you want to set the player's score to 0. Add this code to the top of the balloon's `when FLAG clicked` {.blockevents} code:
 
 	```blocks
 	set [score v] to [0]
@@ -193,7 +193,7 @@ One simple way to get lots of balloons is just to right-click on the balloon spr
 
 + A much better way of getting lots of balloons is to _clone_ the balloon sprite.
 
-	Drag your balloon `when flag clicked` {.blockevents} code (except the `score` {.blockdata} block) off of the event (don't delete it), and instead add code to create 20 balloon clones.
+	Drag your balloon `when FLAG clicked` {.blockevents} code (except the `score` {.blockdata} block) off of the event (don't delete it), and instead add code to create 20 balloon clones.
 
 	You can now attach the code you've just removed to the `when I start as a clone` {.blockevents} event. You should also replace the `hide` {.blocklooks} block in the balloon-clicking script with a `delete this clone` {.blockcontrol} block.
 
@@ -224,7 +224,7 @@ You can make your game more interesting, by only giving your player 10 seconds t
 	Here's the code to do this, which you can add to your _stage_:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [time v] to [10]
 		repeat until <(time) = [0]>
 			wait (1) secs

--- a/en-GB/Additional Projects/Project Template/Project Template.md
+++ b/en-GB/Additional Projects/Project Template/Project Template.md
@@ -45,7 +45,7 @@ This step shows how to add Scratch code to your project.
 + You can add Scratch code to your project like this:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		point in direction (120 v)
 		set pen color to [#FF0000]
 		pen down
@@ -64,7 +64,7 @@ This step shows how to add Scratch code to your project.
 	You can add:
 
 	+ `Motion` {.blockmotion} blocks, for example `move (10) steps` {.blockmotion} or `if on edge, bounce` {.blockmotion};
-	+ `Event` {.blockevents} blocks, for example `when flag clicked` {.blockevents} or `when I receive [message v]` {.blockevents};
+	+ `Event` {.blockevents} blocks, for example `when FLAG clicked` {.blockevents} or `when I receive [message v]` {.blockevents};
 	+ `Looks` {.blocklooks} blocks, for example `show` {.blocklooks} or `next costume` {.blocklooks}
 	+ `Control` {.blockcontrol} blocks, for example `forever` {.blockcontrol}, or `wait (1) secs` {.blockcontrol};
 	+ `Sound` {.blocksound} blocks, for example `play sound meow` {.blocksound} or `stop all sounds` {.blocksound};

--- a/en-GB/Additional Projects/Snowball Fight/Snowball Fight.md
+++ b/en-GB/Additional Projects/Snowball Fight/Snowball Fight.md
@@ -39,7 +39,7 @@ Let's make a snowball, that you can throw around your stage.
 + First, let's allow the player to change the angle of the snowball. Add this code to your snowball sprite:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		wait (0.5) secs
 		go to x:(-200) y:(-130)
 		point in direction (90 v)
@@ -95,7 +95,7 @@ Let's make a snowball, that you can throw around your stage.
 	Here's how your snowball code should look:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		wait (0.5) secs
 		go to x:(-200) y:(-130)
 		point in direction (90 v)
@@ -129,7 +129,7 @@ Let's make a snowball, that you can throw around your stage.
 
 + Test out your snowball a few times. Does it move at different angles and different speeds?
 
-+ If you want to be able to throw your snowball lots of times, just add a `forever` {.blockcontrol} loop around your snowball `when flag clicked` {.blockevents} code.
++ If you want to be able to throw your snowball lots of times, just add a `forever` {.blockcontrol} loop around your snowball `when FLAG clicked` {.blockevents} code.
 
 	![screenshot](snow-throw.png)
 
@@ -141,7 +141,7 @@ You now have a snowball, but let's make it move a bit more realistically.
 
 + First, let's set a maximum power level, so that the snowball can't be thrown too hard.
 
-	In your snowball's `when flag clicked` {.blockevents} code, we need to increase the power only if it's less than 20. Change your code to:
+	In your snowball's `when FLAG clicked` {.blockevents} code, we need to increase the power only if it's less than 20. Change your code to:
 
 	```blocks
 		repeat until< not <key [space v] pressed?> >
@@ -198,7 +198,7 @@ Let's add in a target for your snowballs!
 + Add this code to your new sprite, so that it says "You got me!" when it gets hit:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if < touching [snowball v]? > then
 				say [You got me!] for (1) secs

--- a/en-GB/Additional Projects/Space Junk/Space Junk.md
+++ b/en-GB/Additional Projects/Space Junk/Space Junk.md
@@ -80,7 +80,7 @@ Let's add some space junk for the cat to avoid.
 + Add this code to make the planet move around the stage forever:
 
 	```scratch
-	when flag clicked
+	when FLAG clicked
 	forever
 		move (2) steps
 		if on edge, bounce
@@ -106,7 +106,7 @@ Let's add some space junk for the cat to avoid.
 	Here's how your planet's code should look:
 
 	```scratch
-	when flag clicked
+	when FLAG clicked
 	forever
 		move (2) steps
 		if on edge, bounce
@@ -140,7 +140,7 @@ Can you avoid the space junk for 30 seconds, and get back to Earth safely?
 + Add this code to your Earth sprite, so that it starts off very small and slowly get's bigger and bigger:
 
 	```scratch
-	when flag clicked
+	when FLAG clicked
 	set size to (10) %
 	forever
 		change size by (0.3)
@@ -162,7 +162,7 @@ Can you avoid the space junk for 30 seconds, and get back to Earth safely?
 + Add this code to your stage, so that the timer counts up forever:
 
 	```scratch
-	when flag clicked
+	when FLAG clicked
 	forever
 		wait (0.1) secs
 		change [time v] by (0.1)
@@ -180,7 +180,7 @@ Can you avoid the space junk for 30 seconds, and get back to Earth safely?
 	Click on your cat sprite, and add this script:
 
 	```scratch
-	when flag clicked
+	when FLAG clicked
 	set [time v] to [0]
 	wait until <(time) > [30]>
 	say [I made it!] for (2) secs

--- a/en-GB/Archived Projects/Desert Race/Desert Race.md
+++ b/en-GB/Archived Projects/Desert Race/Desert Race.md
@@ -78,7 +78,7 @@ When you press the start button does it countdown to the start of the race befor
 We only want the racers to move after the race has started and we want to know when the race has finished so we need a variable to hold that information.
 
 + Add a variable for all sprites called `racing`{.blockorange}. Untick the box next to it so it does not show on the stage.
-+ Now set **racing** to be **0** when the project is first started. Change your `when flag clicked`{.blockyellow} script from before to look like this:
++ Now set **racing** to be **0** when the project is first started. Change your `when FLAG clicked`{.blockyellow} script from before to look like this:
 ```blocks
     when FLAG clicked
         show

--- a/en-GB/Archived Projects/Fireworks/Fireworks.md
+++ b/en-GB/Archived Projects/Fireworks/Fireworks.md
@@ -63,7 +63,7 @@ Click the green flag, place your mouse over the stage and press the space bar.
 
 ## Activity Checklist { .check }
 
-+ Finally, let’s make this work by using the mouse button instead of the space bar. To do this, we can wrap our script in a `forever if mouse down` block, then swap the `when space key pressed` control block for `when flag clicked`. And last but not least make sure the rocket is hidden when everything starts up.
++ Finally, let's make this work by using the mouse button instead of the space bar. To do this, we can wrap our script in a `forever if mouse down` block, then swap the `when space key pressed` control block for `when FLAG clicked`. And last but not least make sure the rocket is hidden when everything starts up.
 ```blocks
 	when FLAG clicked
 		hide

--- a/en-GB/Archived Projects/Fruit Machine/Fruit Machine.md
+++ b/en-GB/Archived Projects/Fruit Machine/Fruit Machine.md
@@ -33,7 +33,7 @@ Now we’ve got some costumes, we want the sprite to change between them.
 ## Activity Checklist { .check }
 
 + Click the `Scripts` tab.
-+ Click `Events` and drag a `when flag clicked` { .blockyellow } into the scripts area. This will be triggered when we click the green flag.
++ Click `Events` and drag a `when FLAG clicked` { .blockyellow } into the scripts area. This will be triggered when we click the green flag.
 + Click the **Control** tab and add a `forever` { .blockyellow } and attach it so it snaps to the bottom.
 + **Click the green flag** in the top right. Notice that a yellow outline is around our script. It’s running because we clicked the green flag, which triggers this.
 + Now click `Looks` and drag in a `next costume` { .blockpurple }
@@ -239,7 +239,7 @@ Different people will have different skills at playing the game. **How could you
 
 One way you could do it is to **adjust the speed the costumes change at**. You can use a variable, called `delay` { .blockorange }, to give the duration of each sprite’s wait block. If the player wins the round, the delay can be reduced a little (to make the game harder). If the player loses the round, the delay can be increased a little (to make the game easier).
 
-You'll probably need to think about using a different way of starting the game each time it is played instead of the `when flag clicked` { .blockyellow } Then you can store values in variables that are remembered between each round of the game.
+You'll probably need to think about using a different way of starting the game each time it is played instead of the `when FLAG clicked` { .blockyellow } Then you can store values in variables that are remembered between each round of the game.
 
 ## Save your project { .save }
 

--- a/en-GB/Archived Projects/Sound Machine/For Students/Scratch Cards/02-05 Sound Machine - Record.md
+++ b/en-GB/Archived Projects/Sound Machine/For Students/Scratch Cards/02-05 Sound Machine - Record.md
@@ -20,7 +20,7 @@ embeds: "*.png"
     Empty the list when you start.
 
     ```scratch
-    when flag clicked
+    when FLAG clicked
     delete (all v) of [notes v]
     ```
 

--- a/en-GB/Term 1/Boat Race/Boat Race.md
+++ b/en-GB/Term 1/Boat Race/Boat Race.md
@@ -43,7 +43,7 @@ You are going to learn how to make a game, in which you'll use the mouse to navi
 + You are going to control the boat with your mouse. Add this code to your boat:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		point in direction (0 v)
 		go to x: (-190) y: (-150)
 		forever
@@ -132,7 +132,7 @@ Let's add a timer to your game, so that the player has to get to the desert isla
 + Add this code to your __stage__, so that the timer counts up until the boat reaches the desert island:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [time v] to [0]
 		forever
 			wait (0.1) secs

--- a/en-GB/Term 1/Ghostbusters/Ghostbusters.md
+++ b/en-GB/Term 1/Ghostbusters/Ghostbusters.md
@@ -32,7 +32,7 @@ You are going to make a ghost-catching game!
 + Add this code to your ghost, so that it repeatedly appears and disappears:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			hide
 			wait (1) secs
@@ -54,7 +54,7 @@ Your ghost is really easy to catch, because it doesn't move!
 + Instead of staying in the same position, you can let Scratch choose random x and y coordinates instead. Add a `go to` {.blockmotion} block to your ghost's code, so that it looks like this:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			hide
 			wait (1) secs
@@ -118,7 +118,7 @@ Let's make things more interesting by keeping score.
 + When a new game is started (by clicking the flag), you should set the player's score to 0:
 
 	```blocks
-	when flag clicked
+	when FLAG clicked
 	set [score v] to [0]
 	```
 
@@ -149,7 +149,7 @@ You can make your game more interesting, by only giving your player 10 seconds t
 	Here's the code to do this, which you can add to your __stage__:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [time v] to [10]
 		repeat until <(time) = [0]>
 			wait (1) secs

--- a/en-GB/Term 1/Lost in Space/Lost in Space.md
+++ b/en-GB/Term 1/Lost in Space/Lost in Space.md
@@ -151,7 +151,7 @@ Let's add some floating space-rock to your animation.
 + Add this code to your rock, to make it bounce around the stage:
 
 	```scratch
-	when flag clicked
+	when FLAG clicked
 	point towards [Earth v]
 	forever
 		move (2) steps

--- a/en-GB/Term 1/Paint Box/Paint Box.md
+++ b/en-GB/Term 1/Paint Box/Paint Box.md
@@ -39,7 +39,7 @@ Let's start by making a pencil, that can be used to draw on the stage.
 + As you'll be using the mouse to draw, you'll want the pencil to follow the mouse `forever` {.blockcontrol}. Add this code to your pencil sprite:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 		  go to [mouse pointer v]
 		end
@@ -131,7 +131,7 @@ Let's add different colour pens to your project, and allow the user to choose be
 		set pen color to [#0000ff]
 	```
 
-+ Finally, you need to tell your pencil sprite what costume and pencil colour to choose, as well as clearing the screen, when your project is started. Add this code to the beginning of the pencil's `when flag clicked` {.blockevents} code (before the `forever` {.blockcontrol} loop):
++ Finally, you need to tell your pencil sprite what costume and pencil colour to choose, as well as clearing the screen, when your project is started. Add this code to the beginning of the pencil's `when FLAG clicked` {.blockevents} code (before the `forever` {.blockcontrol} loop):
 
 	```blocks
 		clear

--- a/en-GB/Term 2/Brain Game/Brain Game.md
+++ b/en-GB/Term 2/Brain Game/Brain Game.md
@@ -35,7 +35,7 @@ Let's start by creating random questions for the player to answer.
 + Add code to your character, to set both of these variables to a `random` {.blockoperators} number between 2 and 12.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [number 1 v] to (pick random (2) to (12))
 		set [number 2 v] to (pick random (2) to (12))
 	```
@@ -43,7 +43,7 @@ Let's start by creating random questions for the player to answer.
 + You can then ask the player for the answer, and let them know if they were right or wrong.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [number 1 v] to (pick random (2) to (12))
 		set [number 2 v] to (pick random (2) to (12))
 		ask (join (number 1)(join [ x ] (number 2))) and wait
@@ -87,7 +87,7 @@ Let's add a 'play' button to your game, so that you can play lots of times.
 + Add this code to your new button.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		show
 
 		when this sprite clicked
@@ -99,7 +99,7 @@ Let's add a 'play' button to your game, so that you can play lots of times.
 
 + You'll need to edit your character's code, so that the game starts when they receive the `start` {.blockevents} message, and not when the flag is clicked.
 
-	Replace the `when flag clicked` {.blockevents} code with `when I receive start` {.blockevents}.
+	Replace the `when FLAG clicked` {.blockevents} code with `when I receive start` {.blockevents}.
 
 	![screenshot](brain-start.png)
 
@@ -138,7 +138,7 @@ Let's add a 'play' button to your game, so that you can play lots of times.
 + You can even change how the button looks when the mouse hovers over it.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		show
 		forever
 		if <touching [mouse-pointer v]?> then

--- a/en-GB/Term 2/Catch the Dots/Catch the Dots.md
+++ b/en-GB/Term 2/Catch the Dots/Catch the Dots.md
@@ -34,7 +34,7 @@ Let's start by creating a controller, that will be used to collect dots.
 + Turn your controller to the right when the right arrow key is pressed:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [right arrow v] pressed?> then
 				turn right (3) degrees
@@ -63,7 +63,7 @@ Let's add some dots for the player to collect with their controller.
 + Add this script to your 'red' dot sprite, to create a new dot clone every few seconds:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		wait (2) secs
 		forever
 			create clone of [myself v]
@@ -148,7 +148,7 @@ Let's make the game get more difficult the longer the player survives, by slowly
 + On your stage, create a new script that sets the delay to a high number, and then slowly reduces the delay time.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [delay v] to (8)
 		repeat until < (delay) = (2)>
 			wait (10) secs

--- a/en-GB/Term 2/Clone Wars/Clone Wars.md
+++ b/en-GB/Term 2/Clone Wars/Clone Wars.md
@@ -35,7 +35,7 @@ Let's make a spaceship that will defend the Earth!
 + Add code to move your spaceship to the left when the left arrow key is pressed. You'll need to use these blocks:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [left arrow v] pressed?> then
 				change x by (-4)
@@ -62,7 +62,7 @@ Let's give the spaceship the ability to fire lightning bolts!
 + When the game is started, the lightning should be hidden until the spaceship fires its laser cannons.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		hide
 	```
 
@@ -70,7 +70,7 @@ Let's give the spaceship the ability to fire lightning bolts!
 
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [space v] pressed?> then
 				create clone of [Lightning v]
@@ -114,7 +114,7 @@ Let's add lots of flying hippos that are trying to destroy your spaceship.
 + Set its rotation style to be left-right only, and add the following code to hide the sprite when the game starts:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		hide
 	```
 
@@ -129,7 +129,7 @@ Let's add lots of flying hippos that are trying to destroy your spaceship.
 + The following code will create a new hippo every few seconds. **The Stage** is a good place for this code to live:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			wait (pick random (2) to (4)) secs
 			create clone of [Hippo1 v]
@@ -168,7 +168,7 @@ Let's add lots of flying hippos that are trying to destroy your spaceship.
 + Add this code to your spaceship so that it switches costume whenever it collides with a flying hippo:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			switch costume to [normal v]
 			wait until <touching [Hippo1 v]>?
@@ -222,7 +222,7 @@ Let's make a fruit bat that throws oranges at your spaceship.
 + Add code to your bat, so that it creates a new orange clone every few seconds.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			wait (pick random (5) to (10)) secs
 			create clone of [Orange v]
@@ -232,7 +232,7 @@ Let's make a fruit bat that throws oranges at your spaceship.
 + Click on your orange sprite and add this code to make each orange clone drop down the stage from the bat towards the spaceship:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		hide
 
 		when I start as a clone
@@ -278,7 +278,7 @@ Let's add a 'game over' message at the end of the game.
 + Add this code to your 'Game Over' sprite, so that the message shows at the end of the game:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		hide
 
 		when I receive [game over v]

--- a/en-GB/Term 2/Create Your Own World/Create Your Own World.md
+++ b/en-GB/Term 2/Create Your Own World/Create Your Own World.md
@@ -35,7 +35,7 @@ Let's start by creating a player that can move around your world.
 + Let's use the arrow keys to move the player around. When the player presses the up arrow, you want the player to move up, by changing its y coordinate. Add this code to the player sprite:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [up arrow v] pressed? > then
 				change y by (2)
@@ -50,7 +50,7 @@ Let's start by creating a player that can move around your world.
 + To move the player to the left, you need to add another `if` {.blockcontrol} block to your player, which changes the x coordinate:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [up arrow v] pressed? > then
 				change y by (2)
@@ -73,7 +73,7 @@ Can you add more code to your player, so that they can move up, down, left and r
 + To fix this, you need to move the player, but then move them back if they're touching a light grey wall. Here's the code you'll need:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [up arrow v] pressed? > then
 				change y by (2)
@@ -153,7 +153,7 @@ Let's add signs to your world, to guide your player on their journey.
 + This sign will only be visible in room 1, so let's add some code to the sign to make sure that this happens:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if < (room) = [1] > then
 				show
@@ -170,7 +170,7 @@ Let's add signs to your world, to guide your player on their journey.
 + A sign isn't much good if it doesn't say anything! Let's add some more code (in another separate block) to display a message if the sign is touching the player:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if < touching [player v]? > then
 				say [Welcome! Can you get to the treasure?]
@@ -205,7 +205,7 @@ Let's add other people to your world that your player can interact with.
 + Add in this code, so that the person talks to your player. This code is very similar to the code you added to your sign:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		go to x: (-200) y: (0)
 		forever
 			if < touching [player v]? > then
@@ -273,7 +273,7 @@ Can you create another enemy in room 3, that patrols up and down through the gap
 + Add code to your coin sprite, to add 1 to your `coins` {.blockdata} once they've been picked up:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		wait until <touching [player v]?>
 		change [coins v] by (1)
 		stop [other scripts in sprite v]
@@ -304,7 +304,7 @@ Can you add more coins to your game? They can be in different rooms, and some co
 + The code for collecting the key is very similar to the code for collecting coins. The difference is that you add the key to your inventory.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		wait until <touching [player v]?>
 		add [blue key] to [inventory v]
 		stop [other scripts in sprite v]
@@ -326,7 +326,7 @@ Can you add more coins to your game? They can be in different rooms, and some co
 + You'll need to hide your blue door to allow your player to pass once you have the blue key in your inventory.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		wait until <[inventory v] contains [blue key]>
 		stop [other scripts in sprite v]
 		hide

--- a/en-GB/Term 2/Dodgeball/Dodgeball.md
+++ b/en-GB/Term 2/Dodgeball/Dodgeball.md
@@ -39,7 +39,7 @@ Let's start by creating a character that can move left and right, as well as cli
 + Let's use the arrow keys to move your character around. When the player presses the right arrow, you want your character to point right, move a few steps and change to the next costume:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			if <key [right arrow v] pressed? > then
 				point in direction (90 v)
@@ -93,7 +93,7 @@ Let's make your character move more realistically, by adding gravity and allowin
 + Add this new code block, which sets the gravity to a negative number, and then uses this to repeatedly change your character's y-coordinate.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [gravity v] to [-4]
 		forever
 			change y by (gravity)
@@ -107,7 +107,7 @@ Let's make your character move more realistically, by adding gravity and allowin
 + Gravity shouldn't move your character through a platform or a pole! Add an `if` {.blockcontrol} block to your code, so that the gravity only works when your character is in mid-air. The gravity code should now look like this:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [gravity v] to [-4]
 		forever
 			if < not < <touching color [#0000FF]?> or <touching color [#FFFF00]?> > > then
@@ -236,7 +236,7 @@ Let's make your game a little harder to complete, by adding lasers!
 + Add code to your laser, to make it switch between the 2 costumes.
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		forever
 			switch costume to [on v]
 			wait (2) secs

--- a/en-GB/Term 2/Memory/Memory.md
+++ b/en-GB/Term 2/Memory/Memory.md
@@ -53,7 +53,7 @@ First, let's create a character that can change to a random sequence of colours 
 + Add this code to your character, to add a random number to your list (and show the correct costume) 5 times:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		delete (all v) of [sequence v]
 		repeat (5)
 			add (pick random (1) to (4)) to [sequence v]
@@ -100,7 +100,7 @@ Let's add 4 buttons, for the player to repeat the sequence they've remembered.
 		end
 	```
 
-+ You could also display some flashing lights once the list is empty, as it means the entire sequence has been guessed correctly. Add this code to the end of your character's `when flag clicked` {.blockevents} script:
++ You could also display some flashing lights once the list is empty, as it means the entire sequence has been guessed correctly. Add this code to the end of your character's `when FLAG clicked` {.blockevents} script:
 
 	```blocks
 		wait until < (length of [sequence v]) = [0]>
@@ -138,7 +138,7 @@ So far, the player only has to remember 5 colours. Let's improve your game, so t
 
 	![screenshot](colour-score.png)
 
-+ This `score` {.blockdata} will be used to decide on the length of the sequence the player has to memorise. So, to begin with the score (and the sequence length) is 3. Add this code block to the start of your character's `when flag clicked` {.blockevents} code:
++ This `score` {.blockdata} will be used to decide on the length of the sequence the player has to memorise. So, to begin with the score (and the sequence length) is 3. Add this code block to the start of your character's `when FLAG clicked` {.blockevents} code:
 
 	```blocks
 		set [score v] to [3]
@@ -160,7 +160,7 @@ So far, the player only has to remember 5 colours. Let's improve your game, so t
 + Finally, you need to add a `forever` {.blockcontrol} loop around the code to generate the sequence, so that a new sequence is created for each level. This is how your character's code should look:
 
 	```blocks
-		when flag clicked
+		when FLAG clicked
 		set [score v] to [3]
 		forever
 			delete (all v) of [sequence v]


### PR DESCRIPTION
Replaced all 'when flag clicked' with 'when FLAG clicked' as latest PDF generator seems to be case sensitive.

I don't know what generates the live PDFs but the ones generated by lesson_format seem fine on my mac. (Using '--pdf phantomjs'), but website ones are broken.