### PR TITLE
Re-encode ES project markdown as UTF-8

### DIFF
--- a/es-ES/Scratch 1/Boat Race/Boat Race.md
+++ b/es-ES/Scratch 1/Boat Race/Boat Race.md
@@ -4,47 +4,47 @@ level: Scratch 1
 language: es-ES
 stylesheet: scratch
 embeds: "*.png"
-materials: ["Recursos para el líder del Club /*.*","Recursos del Proyecto /*.*"]
+materials: ["Recursos para el l√≠der del Club /*.*","Recursos del Proyecto /*.*"]
 ...
 
-# Introducción { .intro }
+# Introducci√≥n { .intro }
 
-Vas a aprender cómo crear un juego en el cual usarás el ratón para navegar tu bote a una isla desierta.
+Vas a aprender c√≥mo crear un juego en el cual usar√°s el rat√≥n para navegar tu bote a una isla desierta.
 
 <div class="scratch-preview">
   <iframe allowtransparency="true" width="485" height="402" src="http://scratch.mit.edu/projects/embed/63957956/?autostart=false" frameborder="0"></iframe>
   <img src="boat-final.png">
 </div>
 
-# Primer paso: Cómo planificar el juego { .activity }
+# Primer paso: C√≥mo planificar el juego { .activity }
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto esté vacío. Puedes encontrar el editor en línea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
++ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto est√© vac√≠o. Puedes encontrar el editor en l√≠nea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
 
-+ Haz clic en el fondo de tu escenario y planifica tu nivel. Deberías agregar:
++ Haz clic en el fondo de tu escenario y planifica tu nivel. Deber√≠as agregar:
 	+ Madera que tu bote tiene que evitar;
 	+ Una isla desierta a la que tu bote tiene que llegar.
 
-	Tu juego podría verse algo así:
+	Tu juego podr√≠a verse algo as√≠:
 
-	![screenshot](boat-bg.png) 
+	![screenshot](boat-bg.png)
 
-# Segundo paso: Cómo controlar el bote { .activity }
+# Segundo paso: C√≥mo controlar el bote { .activity }
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Si el líder de tu club te dio una carpeta de 'Recursos', haz clic en 'Cargar objeto del expediente' y agrega la imagen 'boat.png'. Deberías achicar el objeto y ubicarlo en la posición de comienzo.
++ Si el l√≠der de tu club te dio una carpeta de 'Recursos', haz clic en 'Cargar objeto del expediente' y agrega la imagen 'boat.png'. Deber√≠as achicar el objeto y ubicarlo en la posici√≥n de comienzo.
 
 	![screenshot](boat-boat.png)
 
-	Si no tienes la imagen boat.png, ¡puedes dibujar tu propio bote!
+	Si no tienes la imagen boat.png, ¬°puedes dibujar tu propio bote!
 
-+ Vas a controlar el bote con tu ratón. Agrega este código a tu bote:
++ Vas a controlar el bote con tu rat√≥n. Agrega este c√≥digo a tu bote:
 
 	```blocks
 		al presionar la bandera verde
-		apuntar en dirección (0 v)
+		apuntar en direcci√≥n (0 v)
 		ir a x: (-190) y: (-150)
 		por siempre
 			apuntar hacia [puntero del mouse v]
@@ -52,58 +52,58 @@ Vas a aprender cómo crear un juego en el cual usarás el ratón para navegar tu bo
 		fin
 	```
 
-+ Prueba tu bote haciendo clic en la bandera y moviendo el ratón. ¿Navega el bote hacia el ratón?
++ Prueba tu bote haciendo clic en la bandera y moviendo el rat√≥n. ¬øNavega el bote hacia el rat√≥n?
 
 	![screenshot](boat-mouse.png)
 
-+ ¿Qué sucede si el bote llega al apuntador del ratón?
++ ¬øQu√© sucede si el bote llega al apuntador del rat√≥n?
 
-	Para que esto no suceda, necesitarás agregar un bloque 'si'{.blockcontrol} a tu código, para que el bote solo se mueva si está a más de 5 píxeles del ratón.
+	Para que esto no suceda, necesitar√°s agregar un bloque 'si'{.blockcontrol} a tu c√≥digo, para que el bote solo se mueva si est√° a m√°s de 5 p√≠xeles del rat√≥n.
 
-	![screenshot](boat-pointer.png)	
+	![screenshot](boat-pointer.png)
 
-+ Prueba tu bote una vez más para ver si el problema ha sido resuelto.
++ Prueba tu bote una vez m√°s para ver si el problema ha sido resuelto.
 
 ## Guarda tu proyecto { .save }
 
-# Tercer paso: ¡Choques! { .activity .new-page }
+# Tercer paso: ¬°Choques! { .activity .new-page }
 
-¡Tu bote puede navegar a través de barreras de madera! Arreglemos eso.
+¬°Tu bote puede navegar a trav√©s de barreras de madera! Arreglemos eso.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Necesitarás 2 disfraces para tu bote, uno normal y otro para cuando el bote choca. Duplica el disfraz de tu bote y nómbralos 'normal' y 'chocado'.
++ Necesitar√°s 2 disfraces para tu bote, uno normal y otro para cuando el bote choca. Duplica el disfraz de tu bote y n√≥mbralos 'normal' y 'chocado'.
 
 + Haz clic en tu disfraz 'chocado', y elige la herramienta 'Seleccionar' para tomar partecitas del bote y moverlas y rotarlas por todos lados. Haz que parezca que tu bote ha chocado.
 
 	![screenshot](boat-hit-costume.png)
 
-+ Agrega este código a tu bote, dentro del loop `por siempre` {.blockcontrol}, para que choque cuando toca cualquier trocito de madera marrón:
++ Agrega este c√≥digo a tu bote, dentro del loop `por siempre` {.blockcontrol}, para que choque cuando toca cualquier trocito de madera marr√≥n:
 
 	```blocks
 		si <tocando el color [#603C15]?> entonces
 			cambiar disfraz a [hit v]
 			decir [Noooooo!] por (1) segundos
 			cambiar disfraz a [normal v]
-			apuntar en dirección (0 v)
+			apuntar en direcci√≥n (0 v)
 			ir a x: (-215) y: (-160)
 		fin
 	```
 
-	Este código está dentro del loop `por siempre` {.blockcontrol}, para que tu código constantemente verifique si tu bote ha chocado.
+	Este c√≥digo est√° dentro del loop `por siempre` {.blockcontrol}, para que tu c√≥digo constantemente verifique si tu bote ha chocado.
 
-+ También deberías asegurarte de que al comienzo tu bote siempre se vea 'normal'.
++ Tambi√©n deber√≠as asegurarte de que al comienzo tu bote siempre se vea 'normal'.
 
-+ Ahora si tratas de navegar a través de una barrera de madera, deberías ver que tu bote choca y vuelve al inicio.
++ Ahora si tratas de navegar a trav√©s de una barrera de madera, deber√≠as ver que tu bote choca y vuelve al inicio.
 
 	![screenshot](boat-crash.png)
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Ganar! {.challenge}
-¿Puedes agregar otra declaración `si` {.blockcontrol} al código de tu bote, para que el jugador gane cuando llegue a la isla desierta?
+## Desaf√≠o: ¬°Ganar! {.challenge}
+¬øPuedes agregar otra declaraci√≥n `si` {.blockcontrol} al c√≥digo de tu bote, para que el jugador gane cuando llegue a la isla desierta?
 
-Cuando el bote llega a la isla desierta amarilla, debería decir 'YEAH!' y el juego debería terminar. Tendrás que usar este código:
+Cuando el bote llega a la isla desierta amarilla, deber√≠a decir 'YEAH!' y el juego deber√≠a terminar. Tendr√°s que usar este c√≥digo:
 
 ```bloques
 	decir [YEAH!] por (1) segundos
@@ -114,22 +114,22 @@ Cuando el bote llega a la isla desierta amarilla, debería decir 'YEAH!' y el jue
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Efectos de sonido {.challenge}
-Puedes agregar efectos de sonido a tu juego para cuando el bote choca y para cuando llega a la isla al final del juego. Incluso puedes agregar música de fondo (si necesitas ayuda con esto mira el proyecto 'Banda de Rock' anterior).
+## Desaf√≠o: Efectos de sonido {.challenge}
+Puedes agregar efectos de sonido a tu juego para cuando el bote choca y para cuando llega a la isla al final del juego. Incluso puedes agregar m√∫sica de fondo (si necesitas ayuda con esto mira el proyecto 'Banda de Rock' anterior).
 
 ## Guarda tu proyecto { .save }
 
-# Cuarto paso: Prueba del cronómetro { .activity }
+# Cuarto paso: Prueba del cron√≥metro { .activity }
 
-Agreguemos a tu juego un crnómetro, para que el jugador tenga que llegar a la isla lo más rápido posible.
+Agreguemos a tu juego un crn√≥metro, para que el jugador tenga que llegar a la isla lo m√°s r√°pido posible.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Agrega a tu escenario una nueva variable que se llame `tiempo` {.blockdata}. También puedes cambiar cómo se ve tu nueva variable. Si necesitas ayuda, mira el proyecto "Globos".
++ Agrega a tu escenario una nueva variable que se llame `tiempo` {.blockdata}. Tambi√©n puedes cambiar c√≥mo se ve tu nueva variable. Si necesitas ayuda, mira el proyecto "Globos".
 
 	![screenshot](boat-variable.png)
 
-+ Agrega este código a tu __escenario__, para que el cronómetro cuente hasta que el bote llega a la isla desierta:
++ Agrega este c√≥digo a tu __escenario__, para que el cron√≥metro cuente hasta que el bote llega a la isla desierta:
 
 	```blocks
 		al presionar la bandera verde
@@ -140,23 +140,23 @@ Agreguemos a tu juego un crnómetro, para que el jugador tenga que llegar a la is
 		fin
 	```
 
-+ ¡Ya está! ¡Prueba tu juego para ver qué tan rápido puedes llegar a la isla desierta!
++ ¬°Ya est√°! ¬°Prueba tu juego para ver qu√© tan r√°pido puedes llegar a la isla desierta!
 
 	![screenshot](boat-variable-test.png)
 
 ## Guarda tu proyecto { .save }
 
-# Quinto paso: Obstáculos y fuentes de energía { .activity }
+# Quinto paso: Obst√°culos y fuentes de energ√≠a { .activity }
 
-Este juego es _demasiado_ fácil – agreguemos cosas para hacerlo más interesante.
+Este juego es _demasiado_ f√°cil ‚Äì agreguemos cosas para hacerlo m√°s interesante.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Primero agreguemos algunos "estímulos" a tu juego, que harán que el bote navegue más rápido. Edita el fondo de tu scenario y agrega algunas flechas blancas de energía.
++ Primero agreguemos algunos "est√≠mulos" a tu juego, que har√°n que el bote navegue m√°s r√°pido. Edita el fondo de tu scenario y agrega algunas flechas blancas de energ√≠a.
 
 	![screenshot](boat-boost.png)
 
-+ Ahora puedes agregar código al loop `por siempre` {.blockcontrol} de tu bote, para que se mueva 2 _pasos extra_ cada vez que toca una fuente de energía blanca.
++ Ahora puedes agregar c√≥digo al loop `por siempre` {.blockcontrol} de tu bote, para que se mueva 2 _pasos extra_ cada vez que toca una fuente de energ√≠a blanca.
 
 	```blocks
 		si <tocando el color [#FFFFFF]?> entonces
@@ -164,28 +164,28 @@ Este juego es _demasiado_ fácil – agreguemos cosas para hacerlo más interesante.
 		fin
 	```
 
-+ También puedes agregar una puerta giratoria, que tu bote tiene que evitar. Agrega un nuevo objeto que se llame 'puerta', y que se vea así:
++ Tambi√©n puedes agregar una puerta giratoria, que tu bote tiene que evitar. Agrega un nuevo objeto que se llame 'puerta', y que se vea as√≠:
 
 	![screenshot](boat-gate.png)
 
-	Asegúrate de que el color de la puerta sea igual al color de las otras barreras de madera.
+	Aseg√∫rate de que el color de la puerta sea igual al color de las otras barreras de madera.
 
 + Fija el centro del objeto puerta.
 
 	![screenshot](boat-center.png)
 
-+ Agrega código a tu puerta para hacerla que lentamente gire `por siempre` {.blockcontrol}.
++ Agrega c√≥digo a tu puerta para hacerla que lentamente gire `por siempre` {.blockcontrol}.
 
-+ Prueba tu juego. Ahora deberías tener una puerta giratoria que tienes que evitar.
++ Prueba tu juego. Ahora deber√≠as tener una puerta giratoria que tienes que evitar.
 
 	![screenshot](boat-gate-test.png)
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Más obstáculos! {.challenge .new-page}
-¿Puedes agregar más obstáculos a tu juego? Aquí te damos algunas ideas:
+## Desaf√≠o: ¬°M√°s obst√°culos! {.challenge .new-page}
+¬øPuedes agregar m√°s obst√°culos a tu juego? Aqu√≠ te damos algunas ideas:
 
-+ Podrías agregar cieno verde a tu scenario, lo que frena al jugador cuando lo toca. Para hacerlo puedes usar un bloque `espera` {.blockcontrol}:
++ Podr√≠as agregar cieno verde a tu scenario, lo que frena al jugador cuando lo toca. Para hacerlo puedes usar un bloque `espera` {.blockcontrol}:
 
 ```blocks
 	esperar (0.01) segundos
@@ -193,7 +193,7 @@ Este juego es _demasiado_ fácil – agreguemos cosas para hacerlo más interesante.
 
 ![screenshot](boat-algae.png)
 
-+ ¡Podrías agregar un objeto en movimiento, como un tronco o un tiburón!
++ ¬°Podr√≠as agregar un objeto en movimiento, como un tronco o un tibur√≥n!
 
 ![screenshot](boat-obstacles.png)
 
@@ -204,7 +204,7 @@ Estos bloques pueden ayudarte:
 	rebotar si toca un borde
 ````
 
-Si tu nuevo objeto no es marrón, tendrás que agregar esto al código de tu bote:
+Si tu nuevo objeto no es marr√≥n, tendr√°s que agregar esto al c√≥digo de tu bote:
 
 ```blocks
 	si <  <tocando el color [#603C15]?> o <tocando [shark v]?> > entonces
@@ -213,31 +213,31 @@ Si tu nuevo objeto no es marrón, tendrás que agregar esto al código de tu bote:
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Más botes! {.challenge .new-page}
-¿Puedes convertir tu juego en una carrera entre 2 jugadores?
+## Desaf√≠o: ¬°M√°s botes! {.challenge .new-page}
+¬øPuedes convertir tu juego en una carrera entre 2 jugadores?
 
-+ Duplica el bote, renómbralo 'Jugador 2' y cámbiale el color.
++ Duplica el bote, ren√≥mbralo 'Jugador 2' y c√°mbiale el color.
 
 ![screenshot](boat-p2.png)
 
-+ Cambia este código para cambiar la posición de comienzo del Jugador 2:
++ Cambia este c√≥digo para cambiar la posici√≥n de comienzo del Jugador 2:
 
 ```blocks
 	ir a x: (-190) y: (-150)
 ```
 
-+ Borra el código que usa el ratón para controlar el bote:
++ Borra el c√≥digo que usa el rat√≥n para controlar el bote:
 
 ```blocks
 	si < (distancia a [puntero del mouse v]) > [5] > entonces
-		apuntar hacia [apuntador del ratón v]
+		apuntar hacia [apuntador del rat√≥n v]
 		mover (1) pasos
 	fin
 ```
 
-...y reemplázalo con código para controlar el bote usando las teclas de flechas.
+...y reempl√°zalo con c√≥digo para controlar el bote usando las teclas de flechas.
 
-Este es el código que necesitas para mover el bote hacia adelante:
+Este es el c√≥digo que necesitas para mover el bote hacia adelante:
 
 ```blocks
 	si < tecla [flecha arriba v] presionada? > entonces
@@ -245,12 +245,12 @@ Este es el código que necesitas para mover el bote hacia adelante:
 	fin
 ```
 
-También necesitarás un código para `doblar` {.blockmotion} el bote cuando se presionan las teclas de flechas izquierda y derecha.
+Tambi√©n necesitar√°s un c√≥digo para `doblar` {.blockmotion} el bote cuando se presionan las teclas de flechas izquierda y derecha.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Más niveles! {.challenge .new-page}
-¿Puedes crear escenarios adicionales y permitirle al jugador que elija entre niveles?
+## Desaf√≠o: ¬°M√°s niveles! {.challenge .new-page}
+¬øPuedes crear escenarios adicionales y permitirle al jugador que elija entre niveles?
 
 ```blocks
 	al presionar la tecla [espacio v]

--- a/es-ES/Scratch 1/ChatBot/ChatBot.md
+++ b/es-ES/Scratch 1/ChatBot/ChatBot.md
@@ -1,102 +1,102 @@
 ---
-title: Robot parlanchín
+title: Robot parlanch√≠n
 level: Scratch 1
 language: es-ES
 stylesheet: scratch
 embeds: "*.png"
-materials: ["Recursos para el Líder del Club /*.*"]
+materials: ["Recursos para el L√≠der del Club /*.*"]
 ...
 
-# Introducción { .intro }
+# Introducci√≥n { .intro }
 
-¡Vas a aprender cómo programar tu propio robot que habla!
+¬°Vas a aprender c√≥mo programar tu propio robot que habla!
 
 <div class="scratch-preview">
   <iframe allowtransparency="true" width="485" height="402" src="http://scratch.mit.edu/projects/embed/26762091/?autostart=false" frameborder="0"></iframe>
   <img src="chatbot-final.png">
 </div>
 
-# Primer paso: Tu robot parlanchín { .activity }
+# Primer paso: Tu robot parlanch√≠n { .activity }
 
-## Lista de verifiación de actividades { .check }
+## Lista de verifiaci√≥n de actividades { .check }
 
-+ Antes de comenzar a hacer tu robot parlanchín, necesitas decidir sobre su personalidad.
-	+ ¿Cómo se llama?
-	+ ¿Dónde vive?
-	+ ¿Es feliz? ¿serio? ¿gracioso? ¿tímido? ¿amigable?
++ Antes de comenzar a hacer tu robot parlanch√≠n, necesitas decidir sobre su personalidad.
+	+ ¬øC√≥mo se llama?
+	+ ¬øD√≥nde vive?
+	+ ¬øEs feliz? ¬øserio? ¬øgracioso? ¬øt√≠mido? ¬øamigable?
 
-+ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto esté vacío. Puedes encontrar el editor en línea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
++ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto est√© vac√≠o. Puedes encontrar el editor en l√≠nea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
 
-+ Elige uno de estos caracteres objetos, y agrégalos a tu proyecto:
++ Elige uno de estos caracteres objetos, y agr√©galos a tu proyecto:
 
 	![screenshot](chatbot-characters.png)
 
-+ Crea un escenario que haga juego con la personalidad de tu robot parlanchín. Aquí te  damos un ejemplo, aunque no necesariamente tiene que  verse así:
++ Crea un escenario que haga juego con la personalidad de tu robot parlanch√≠n. Aqu√≠ te  damos un ejemplo, aunque no necesariamente tiene que  verse as√≠:
 
 	![screenshot](chatbot-sprite.png)
 
 ## Guarda tu proyecto { .save }
 
-# Segundo paso: Un robot parlanchín que puede hablar { .activity }
+# Segundo paso: Un robot parlanch√≠n que puede hablar { .activity }
 
-Ahora que tienes un robot parlanchín con personalidad, creemos un programa para que te hable.
+Ahora que tienes un robot parlanch√≠n con personalidad, creemos un programa para que te hable.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Haz clic en el caracter de tu robot parlanchín, y agrega este código:
++ Haz clic en el caracter de tu robot parlanch√≠n, y agrega este c√≥digo:
 
 	```blocks
 		al hacer clic en este objeto
-		preguntar [Hey! Cómo te llamas?] y esperar
-		decir [Qué lindo nombre!] por (2) segundos
+		preguntar [Hey! C√≥mo te llamas?] y esperar
+		decir [Qu√© lindo nombre!] por (2) segundos
 	```
 
-+ Haz clic en tu robot parlanchín para probarlo. Luego de que te pregunta tu nombre, escríbelo en la caja abajo del escenario.
++ Haz clic en tu robot parlanch√≠n para probarlo. Luego de que te pregunta tu nombre, escr√≠belo en la caja abajo del escenario.
 
 	![screenshot](chatbot-text.png)
 
-+ Tu robot parlanchín simplemente responde `Qué lindo nombre!` cada vez. Puedes personalizar la respuesta de tu robot parlanchín, haciendo uso de la respuesta del usuario. Cambia el código del robot parlanchín, para que se vea así:
++ Tu robot parlanch√≠n simplemente responde `Qu√© lindo nombre!` cada vez. Puedes personalizar la respuesta de tu robot parlanch√≠n, haciendo uso de la respuesta del usuario. Cambia el c√≥digo del robot parlanch√≠n, para que se vea as√≠:
 
 	```blocks
 		al hacer clic en este objeto
-		preguntar [Hey! Cómo te llamas?] y esperar
+		preguntar [Hey! C√≥mo te llamas?] y esperar
 		decir <unir [Hola] (respuesta)> por (2) segundos
 	```
 
-	Para crear este último bloque, primero tendrás que arrastrar un bloque verde `unir` {.blockoperators} , y arrastrarlo sobre el bloque `decir` {.blocklooks} .
+	Para crear este √∫ltimo bloque, primero tendr√°s que arrastrar un bloque verde `unir` {.blockoperators} , y arrastrarlo sobre el bloque `decir` {.blocklooks} .
 
 	![screenshot](chatbot-join.png)
 
-	Puedes cambiar el texto `hola` para decir `Hey`, y arrastrar el bloque azul `respuesta` {.blocksensing}  (de la sección 'Percepción' ) sobre el texto `mundo`.
+	Puedes cambiar el texto `hola` para decir `Hey`, y arrastrar el bloque azul `respuesta` {.blocksensing}  (de la secci√≥n 'Percepci√≥n' ) sobre el texto `mundo`.
 
 	![screenshot](chatbot-answer.png)
 
-+ Prueba este nuevo programa. ¿Funciona como esperabas? ¿Puedes solucionar los problemas que ves? (Pista: ¡puedes intentar agregar un espacio en cualquier parte!)
++ Prueba este nuevo programa. ¬øFunciona como esperabas? ¬øPuedes solucionar los problemas que ves? (Pista: ¬°puedes intentar agregar un espacio en cualquier parte!)
 
 + Puede que quieras almacenar el nombre del usuario en una variable, para poder usarlo de nuevo en el futuro. Crea una nueva variable que se llame `nombre` {.blockdata}. Si olvidaste como hacerlo, el proyecto "Globos" puede ayudarte.
 
-+ La información que ingresaste ya está almacenada en una variable especial llamada `respuesta` {.blocksensing}. Ve al grupo de bloques de Percepción y haz clic en el bloque de respuesta para que aparezca una palomita. El valor actual en `respuesta` {.blocksensing} debería mostrarse en la parte superior izquierda del escenario.
++ La informaci√≥n que ingresaste ya est√° almacenada en una variable especial llamada `respuesta` {.blocksensing}. Ve al grupo de bloques de Percepci√≥n y haz clic en el bloque de respuesta para que aparezca una palomita. El valor actual en `respuesta` {.blocksensing} deber√≠a mostrarse en la parte superior izquierda del escenario.
 
-+ Una vez que creaste tu nueva variable, asegúrate de que el código de tu robot parlanchín se vea así:
++ Una vez que creaste tu nueva variable, aseg√∫rate de que el c√≥digo de tu robot parlanch√≠n se vea as√≠:
 
 	```blocks
 		al hacer clic en este objeto
-		preguntar [Hey! Cómo te llamas?] y esperar
+		preguntar [Hey! C√≥mo te llamas?] y esperar
 		fijar [name v] a (answer)
 		decir <unir [Hola ] (name)> por (2) segundos
 	```
 
-+ Si pruebas el programa una vez más, verás que la respuesta se almacena en la variable `nombre` {.blockdata} , y se muestra en la parte superior izquierda del escenario. La variable `nombre` {.blockdata} debería ahora contener el mismo valor que la variable `respuesta` {.blocksensing} .
++ Si pruebas el programa una vez m√°s, ver√°s que la respuesta se almacena en la variable `nombre` {.blockdata} , y se muestra en la parte superior izquierda del escenario. La variable `nombre` {.blockdata} deber√≠a ahora contener el mismo valor que la variable `respuesta` {.blocksensing} .
 
 	![screenshot](chatbot-variable.png)
 
-	Si prefieres no ver las variables en tu escenario, puedes hacer clic en la palomita junto al nombre de la variable en la leng üeta "Secuencia de comandos" para esconderlas.
+	Si prefieres no ver las variables en tu escenario, puedes hacer clic en la palomita junto al nombre de la variable en la leng √ºeta "Secuencia de comandos" para esconderlas.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Más preguntas { .challenge }
+## Desaf√≠o: M√°s preguntas { .challenge }
 
-Programa tu robot parlanchín para que haga otra pregunta. ¿Puedes almacenar su respuesta en una variable?
+Programa tu robot parlanch√≠n para que haga otra pregunta. ¬øPuedes almacenar su respuesta en una variable?
 
 ![screenshot](chatbot-question.png)
 
@@ -104,100 +104,100 @@ Programa tu robot parlanchín para que haga otra pregunta. ¿Puedes almacenar su r
 
 # Tercer paso: La toma de decisiones { .activity }
 
-Puedes programar tu robot parlanchín para que decida qué hacer, basándose en las respuestas del usuario.
+Puedes programar tu robot parlanch√≠n para que decida qu√© hacer, bas√°ndose en las respuestas del usuario.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Hagamos que tu robot parlanchín pregunte al usuario una pregunta con una respuesta `sí` o `no` . Aquí te damos un ejemplo, pero puedes cambiar la pregunta si así lo deseas:
++ Hagamos que tu robot parlanch√≠n pregunte al usuario una pregunta con una respuesta `s√≠` o `no` . Aqu√≠ te damos un ejemplo, pero puedes cambiar la pregunta si as√≠ lo deseas:
 
 	```blocks
 		al hacer clic en este objeto
-		preguntar [Hey! Cómo te llamas?] y esperar
+		preguntar [Hey! C√≥mo te llamas?] y esperar
 		fijar [name v] a (answer)
 		decir <unir [Hola ] (name)> por (2) segundos
-		preguntar <unir [Estás bien ] (name)> y esperar
-		si ((respuesta)=[sí]) entonces
-			decir [Me da gusto saber que estás bien!] por (2) segundos
+		preguntar <unir [Est√°s bien ] (name)> y esperar
+		si ((respuesta)=[s√≠]) entonces
+			decir [Me da gusto saber que est√°s bien!] por (2) segundos
 		fin
 	```
 
-	Fíjate que ahora que has guardado el nombre del usuario en una variable, puedes usarlo cuantas veces quieras.
+	F√≠jate que ahora que has guardado el nombre del usuario en una variable, puedes usarlo cuantas veces quieras.
 
-+ Para probar el programa adecuadamente, tendrás que probarlo dos veces, una escribiendo `no` como tu respuesta, y otra escribiendo `sí`. Solo deberías obtener una respuesta de tu robot parlanchín `si` {.blockcontrol} tu respuesta es `sí`.
++ Para probar el programa adecuadamente, tendr√°s que probarlo dos veces, una escribiendo `no` como tu respuesta, y otra escribiendo `s√≠`. Solo deber√≠as obtener una respuesta de tu robot parlanch√≠n `si` {.blockcontrol} tu respuesta es `s√≠`.
 
-+ El problema con tu robot parlanchín es que no te da una respuesta si el usuario contesta `no`. Puedes solucionar esto cambiando el bloque `si` {.blockcontrol} por un bloque `si/si no` {.blockcontrol} , para que tu nuevo código se vea así:
++ El problema con tu robot parlanch√≠n es que no te da una respuesta si el usuario contesta `no`. Puedes solucionar esto cambiando el bloque `si` {.blockcontrol} por un bloque `si/si no` {.blockcontrol} , para que tu nuevo c√≥digo se vea as√≠:
 
 	```blocks
 		al hacer clic en este objeto
-		preguntar [Hey! Cómo te llamas?] y esperar
+		preguntar [Hey! C√≥mo te llamas?] y esperar
 		fijar [name v] a (answer)
 		decir <unir [Hola ] (name)> por (2) segundos
-		preguntar <unir [Estás bien ] (name)> y esperar
-		si ((respuesta)=[sí]) entonces
-			decir [Me da gusto saber que estás bien!] por (2) segundos
+		preguntar <unir [Est√°s bien ] (name)> y esperar
+		si ((respuesta)=[s√≠]) entonces
+			decir [Me da gusto saber que est√°s bien!] por (2) segundos
 		si no
 			decir [Oh no!] por (2) segundos
 		fin
 	```
 
-+ Si pruebas tu código, verás ahora que obtienes una respuesta si contestas `sí` o `no`. Tu robot parlanchín debería responder con `Me da gusto saber que estás bien!` cuando contestas `sí`, pero responderá `Oh no!` si escribes otra cosa que no sea `sí` (`si no` {.blockcontrol} significa "de lo contrario").
++ Si pruebas tu c√≥digo, ver√°s ahora que obtienes una respuesta si contestas `s√≠` o `no`. Tu robot parlanch√≠n deber√≠a responder con `Me da gusto saber que est√°s bien!` cuando contestas `s√≠`, pero responder√° `Oh no!` si escribes otra cosa que no sea `s√≠` (`si no` {.blockcontrol} significa "de lo contrario").
 
 	![screenshot](chatbot-else.png)
 
-+ Puedes poner cualquier código dentro de un bloque `si` {.blockcontrol} o `si no` {.blockcontrol} , no solo el código para hacer que tu robot parlanchín hable. Por ejemplo, puedes cambiar el disfraz de tu robot parlanchín para que coincida con la respuesta.
++ Puedes poner cualquier c√≥digo dentro de un bloque `si` {.blockcontrol} o `si no` {.blockcontrol} , no solo el c√≥digo para hacer que tu robot parlanch√≠n hable. Por ejemplo, puedes cambiar el disfraz de tu robot parlanch√≠n para que coincida con la respuesta.
 
-	Si miras los disfraces de tu robot parlanchín, verás que hay más de uno. (Si no los hay, ¡siempre puedes agregar más tu mismo!)
+	Si miras los disfraces de tu robot parlanch√≠n, ver√°s que hay m√°s de uno. (Si no los hay, ¬°siempre puedes agregar m√°s tu mismo!)
 
 	![screenshot](chatbot-costumes.png)
 
-	Puedes usar estos disfraces como parte de la respuesta de tu robot parlanchín, agregando este código:
+	Puedes usar estos disfraces como parte de la respuesta de tu robot parlanch√≠n, agregando este c√≥digo:
 
 	![screenshot](chatbot-costumes-code.png)
 
-+ Prueba tu programa, y deberías ver cómo la cara de tu robot parlanchín cambia dependiendo de la respuesta que le das.
++ Prueba tu programa, y deber√≠as ver c√≥mo la cara de tu robot parlanch√≠n cambia dependiendo de la respuesta que le das.
 
 	![screenshot](chatbot-face.png)
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Más decisiones { .challenge }
+## Desaf√≠o: M√°s decisiones { .challenge }
 
-Programa tu robot parlanchín para hacer otra pregunta, algo que tenga una respuesta `sí` o `no` . Puedes hacer que tu robot parlanchín responda a la respuesta?
+Programa tu robot parlanch√≠n para hacer otra pregunta, algo que tenga una respuesta `s√≠` o `no` . Puedes hacer que tu robot parlanch√≠n responda a la respuesta?
 
 ![screenshot](chatbot-joke.png)
 
 ## Guarda tu proyecto { .save }
 
-# Cuarto paso: Cómo cambiar la ubicación { .activity }
+# Cuarto paso: C√≥mo cambiar la ubicaci√≥n { .activity }
 
-También puedes programar a tu robot parlanchín para que cambie su ubicación.
+Tambi√©n puedes programar a tu robot parlanch√≠n para que cambie su ubicaci√≥n.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
 + Agrega otro fondo a tu escenario, por ejemplo el fondo "luna".
 
 	![screenshot](chatbot-moon.png)
 
-+ Ahora puedes programar a tu robot parlanchín para que cambie de ubicación agregando este código a tu robot parlanchín:
++ Ahora puedes programar a tu robot parlanch√≠n para que cambie de ubicaci√≥n agregando este c√≥digo a tu robot parlanch√≠n:
 
 	```blocks
-		preguntar [Me voy a la luna. ¿Quieres venir conmigo?] y esperar
-		si ((respuesta) = [sí]) entonces
+		preguntar [Me voy a la luna. ¬øQuieres venir conmigo?] y esperar
+		si ((respuesta) = [s√≠]) entonces
 			cambiar fondo a [moon v]
 		fin
 	```
 
-+ También debes asegurarte de que tu robot parlanchín esté afuera cuando comienzas a hablarle. Agrega este bloque al principio del código de tu robot parlanchín:
++ Tambi√©n debes asegurarte de que tu robot parlanch√≠n est√© afuera cuando comienzas a hablarle. Agrega este bloque al principio del c√≥digo de tu robot parlanch√≠n:
 
 	![screenshot](chatbot-outside.png)
 
-+ Prueba tu programa, y contesta `sí` cuando te pregunta si quieres ir a la luna. Deberías ver que la ubicación del robot parlanchín cambió.
++ Prueba tu programa, y contesta `s√≠` cuando te pregunta si quieres ir a la luna. Deber√≠as ver que la ubicaci√≥n del robot parlanch√≠n cambi√≥.
 
 	![screenshot](chatbot-backdrop.png)
 
-+ ¿Cambia de ubicación tu robot parlanchín si escribes `no`? ¿Y qué pasa si escribes `No estoy seguro`?
++ ¬øCambia de ubicaci√≥n tu robot parlanch√≠n si escribes `no`? ¬øY qu√© pasa si escribes `No estoy seguro`?
 
-+ También puedes agregar este código dentro de tu bloque `si` {.blockcontrol} , para hacer que tu robot parlanchín salte 4 veces si la respuesta es `sí`:
++ Tambi√©n puedes agregar este c√≥digo dentro de tu bloque `si` {.blockcontrol} , para hacer que tu robot parlanch√≠n salte 4 veces si la respuesta es `s√≠`:
 
 	```scratch
 	repetir (4)
@@ -210,15 +210,15 @@ También puedes programar a tu robot parlanchín para que cambie su ubicación.
 
 	![screenshot](chatbot-loop.png)
 
-+ Prueba tu código una vez más. ¿Salta tu robot parlanchín si contestas que `sí`?
++ Prueba tu c√≥digo una vez m√°s. ¬øSalta tu robot parlanch√≠n si contestas que `s√≠`?
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Crea tu propio robot parlanchín {.challenge}
-Utiliza lo que has aprendido para terminar de crear tu robot parlanchín interactivo. Aquí te damos algunas ideas:
+## Desaf√≠o: Crea tu propio robot parlanch√≠n {.challenge}
+Utiliza lo que has aprendido para terminar de crear tu robot parlanch√≠n interactivo. Aqu√≠ te damos algunas ideas:
 
 ![screenshot](chatbot-ideas.png)
 
-Una vez que termines de crear tu robot parlanchín, ¡haz que tus amigos hablen con él! ¿Les gusta tu personaje? ¿Encontraron algún problema?
+Una vez que termines de crear tu robot parlanch√≠n, ¬°haz que tus amigos hablen con √©l! ¬øLes gusta tu personaje? ¬øEncontraron alg√∫n problema?
 
 ## Guarda tu proyecto { .save }

--- a/es-ES/Scratch 1/Ghostbusters/Ghostbusters.md
+++ b/es-ES/Scratch 1/Ghostbusters/Ghostbusters.md
@@ -4,32 +4,32 @@ level: Scratch 1
 language: es-ES
 stylesheet: scratch
 embeds: "*.png"
-materials: ["Recursos para el líder del club/*.*"]
+materials: ["Recursos para el l√≠der del club/*.*"]
 ...
 
 ## Nota: { .challenge .pdf-hidden }
-El Proyecto “Globos” se ha movido a la sección [Proyectos Scratch Adicionales](http://projects.codeclub.org.uk/en-GB/03_scratch_bonus/index.html.
+El Proyecto ‚ÄúGlobos‚Äù se ha movido a la secci√≥n [Proyectos Scratch Adicionales](http://projects.codeclub.org.uk/en-GB/03_scratch_bonus/index.html.
 
-# Introducción { .intro }
+# Introducci√≥n { .intro }
 
-¡Vas a crear un juego para cazar fantasmas!
+¬°Vas a crear un juego para cazar fantasmas!
 
 <div class="scratch-preview">
   <iframe allowtransparency="true" width="485" height="402" src="http://scratch.mit.edu/projects/embed/60787262/?autostart=false" frameborder="0"></iframe>
   <img src="ghost-final.png">
 </div>
 
-# Primer paso: Cómo animar un fantasma { .activity }
+# Primer paso: C√≥mo animar un fantasma { .activity }
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto esté vacío. Puedes encontrar el editor en línea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
++ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto est√© vac√≠o. Puedes encontrar el editor en l√≠nea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
 
 + Agrega un nuevo objeto fantasma, y un escenario acorde.
 
 	![screenshot](ghost-ghost.png)
 
-+ Agrega este código a tu fantasma, para que continuamente aparezca y desaparezca:
++ Agrega este c√≥digo a tu fantasma, para que continuamente aparezca y desaparezca:
 
 	```blocks
 		al presionar la bandera verde
@@ -41,81 +41,81 @@ El Proyecto “Globos” se ha movido a la sección [Proyectos Scratch Adicionales](h
 		fin
 	```
 
-+ Prueba el código de tu fantasma haciendo clic en la bandera verde.
++ Prueba el c√≥digo de tu fantasma haciendo clic en la bandera verde.
 
 ## Guarda tu proyecto { .save }
 
 # Segundo paso: Fantasmas aleatorios { .activity }
 
-¡Tu fantasma es muy fácil de atrapar porque no se mueve!
+¬°Tu fantasma es muy f√°cil de atrapar porque no se mueve!
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ En lugar de estar en la misma posición, puedes hacer que Scratch elija coordinadas x e y al azar. Agregar un bloque `ir a` {.blockmotion} al código de tu fantasma, para que se vea así:
++ En lugar de estar en la misma posici√≥n, puedes hacer que Scratch elija coordinadas x e y al azar. Agregar un bloque `ir a` {.blockmotion} al c√≥digo de tu fantasma, para que se vea as√≠:
 
 	```blocks
 		al presionar bandera verde
 		por siempre
 			esconder
 			esperar (1) segundos
-			ir a x:(número al azar entre (-150) y (150)) y:(número al azar entre (-150) y (150))
+			ir a x:(n√∫mero al azar entre (-150) y (150)) y:(n√∫mero al azar entre (-150) y (150))
 			mostrar
 			esperar (1) segundos
 		fin
 	```
 
-+ Prueba tu fantasma una vez más. Deberías notar que cada vez aparece en un lugar distinto.
++ Prueba tu fantasma una vez m√°s. Deber√≠as notar que cada vez aparece en un lugar distinto.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Más aleatoriedad {.challenge}
-¿Puedes hacer que tu fantasma `espere` {.blockcontrol} una cantidad de tiempo al azar antes de aparecer? ¿Puedes usar el bloque `fijar tamaño ` {.blocklooks} para hacer que tu fantasma tenga un tamaño al azar cada vez que aparece?
+## Desaf√≠o: M√°s aleatoriedad {.challenge}
+¬øPuedes hacer que tu fantasma `espere` {.blockcontrol} una cantidad de tiempo al azar antes de aparecer? ¬øPuedes usar el bloque `fijar tama√±o ` {.blocklooks} para hacer que tu fantasma tenga un tama√±o al azar cada vez que aparece?
 
 ## Guarda tu proyecto { .save }
 
-# Tercer paso: Cómo atrapar fantasmas { .activity }
+# Tercer paso: C√≥mo atrapar fantasmas { .activity }
 
-¡Dejemos que el jugador pueda atrapar fantasmas!
+¬°Dejemos que el jugador pueda atrapar fantasmas!
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Para permitirle al jugador que atrape un fantasma, agrega este código:
++ Para permitirle al jugador que atrape un fantasma, agrega este c√≥digo:
 
 	```blocks
 		al hacer clic en este objeto
 		esconder
 	```
 
-+ Prueba tu proyecto. ¿Puedes atrapar fantasmas cuando aparecen? Si te parece difícil atrapar fantasmas, puedes jugar el juego en el modo pantalla completa haciendo clic en este botón:
++ Prueba tu proyecto. ¬øPuedes atrapar fantasmas cuando aparecen? Si te parece dif√≠cil atrapar fantasmas, puedes jugar el juego en el modo pantalla completa haciendo clic en este bot√≥n:
 
 	![screenshot](ghost-fullscreen.png)
 
-## Desafío: Agregar un sonido { .challenge }
-¿Puedes hacer un sonido cada vez que se atrapa un fantasma?
+## Desaf√≠o: Agregar un sonido { .challenge }
+¬øPuedes hacer un sonido cada vez que se atrapa un fantasma?
 
 ## Guarda tu proyecto { .save }
 
 # Cuarto paso: Agregar un puntaje { .activity .new-page }
 
-Hagamos que las cosas sean más interesantes con un contador de puntos.
+Hagamos que las cosas sean m√°s interesantes con un contador de puntos.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Para llevar un conteo de los puntos del jugador, necesitas un lugar para ubicarlo. Una __variable__ es un lugar para almacenar información que cambia, como un puntaje.
++ Para llevar un conteo de los puntos del jugador, necesitas un lugar para ubicarlo. Una __variable__ es un lugar para almacenar informaci√≥n que cambia, como un puntaje.
 
-	Para crear una nueva variable, haz clic en la lengüeta de “Secuencia de comandos”, selecciona `Información` {.blockdata} y luego haz clic en “Crear una Variable”.
+	Para crear una nueva variable, haz clic en la leng√ºeta de ‚ÄúSecuencia de comandos‚Äù, selecciona `Informaci√≥n` {.blockdata} y luego haz clic en ‚ÄúCrear una Variable‚Äù.
 
 	![screenshot](ghost-score.png)
 
-	Ingresa “puntaje” como el nombre de la variable. Asegúrate de que esté disponible para todos los objetos, y haz clic en “OK” para crearla. Verás muchísimos bloques de código que pueden usarse con tu variable `puntaje` {.blockdata}.
+	Ingresa ‚Äúpuntaje‚Äù como el nombre de la variable. Aseg√∫rate de que est√© disponible para todos los objetos, y haz clic en ‚ÄúOK‚Äù para crearla. Ver√°s much√≠simos bloques de c√≥digo que pueden usarse con tu variable `puntaje` {.blockdata}.
 
 	![screenshot](ghost-variable.png)
 
-	También verás el puntaje en la esquina superior izquierda del escenario.
+	Tambi√©n ver√°s el puntaje en la esquina superior izquierda del escenario.
 
 	![screenshot](ghost-stage-score.png)
 
-+ Cuando se inicia un nuevo juego (haciendo clic en la bandera), deberías hacer que el puntaje del jugador sea 0:
++ Cuando se inicia un nuevo juego (haciendo clic en la bandera), deber√≠as hacer que el puntaje del jugador sea 0:
 
 	```blocks
 	al presionar bandera verde
@@ -126,27 +126,27 @@ Hagamos que las cosas sean más interesantes con un contador de puntos.
 
 	![screenshot](ghost-change-score.png)
 
-+ Ejecuta tu programa une vez más y atrapa algunos fantasmas. ¿Cambia tu puntaje?
++ Ejecuta tu programa une vez m√°s y atrapa algunos fantasmas. ¬øCambia tu puntaje?
 
 ## Guarda tu proyecto { .save }
 
-# Quinto paso: Cómo agregar un cronómetro { .activity }
+# Quinto paso: C√≥mo agregar un cron√≥metro { .activity }
 
-Puedes hacer tu juego más interesante, dándole al jugador solo 10 segundos para atrapar tantos fantasmas como le sea posible.
+Puedes hacer tu juego m√°s interesante, d√°ndole al jugador solo 10 segundos para atrapar tantos fantasmas como le sea posible.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Puedes usar otra variable para almacenar el tiempo que queda. Haz clic en el escenario y crea una nueva variable denominada “tiempo”:
++ Puedes usar otra variable para almacenar el tiempo que queda. Haz clic en el escenario y crea una nueva variable denominada ‚Äútiempo‚Äù:
 
 	![screenshot](ghost-time.png)
 
-+ Así es como debería funcionar el cronómetro:
++ As√≠ es como deber√≠a funcionar el cron√≥metro:
 
-	+ El cronómetro debería comenzar a 10 segundos;
-	+ El cronómetro debería contar cada segundo descendiente;
-	+ El juego debería detenerse cuando el cronómetro llega a 0.
+	+ El cron√≥metro deber√≠a comenzar a 10 segundos;
+	+ El cron√≥metro deber√≠a contar cada segundo descendiente;
+	+ El juego deber√≠a detenerse cuando el cron√≥metro llega a 0.
 
-	Este es el código para hacerlo, que puedes agregar a tu __escenario__:
+	Este es el c√≥digo para hacerlo, que puedes agregar a tu __escenario__:
 
 	```blocks
 		al presionar bandera verde
@@ -158,36 +158,36 @@ Puedes hacer tu juego más interesante, dándole al jugador solo 10 segundos para 
 		detener [todos v]
 	```
 
-	Así es como agregas el código `repetir hasta`{.blockcontrol}`tiempo`{.blockdata}`= 0`{.blockoperators}:
+	As√≠ es como agregas el c√≥digo `repetir hasta`{.blockcontrol}`tiempo`{.blockdata}`= 0`{.blockoperators}:
 
 	![screenshot](ghost-timer-help.png)
 
-+ Arrastra el visor de la variable “tiempo” al lado derecho del scenario. También puedes hacer clic con el botón derecho en el visor de la variable y elegir “lector grande” para cambiar cómo se muestra el tiempo.
++ Arrastra el visor de la variable ‚Äútiempo‚Äù al lado derecho del scenario. Tambi√©n puedes hacer clic con el bot√≥n derecho en el visor de la variable y elegir ‚Äúlector grande‚Äù para cambiar c√≥mo se muestra el tiempo.
 
 	![screenshot](ghost-readout.png)
 
-+ Pídele a un amigo que pruebe tu juego. ¿Cuántos puntos pueden sumar? Si tu juego es demasiado fácil, puedes:
++ P√≠dele a un amigo que pruebe tu juego. ¬øCu√°ntos puntos pueden sumar? Si tu juego es demasiado f√°cil, puedes:
 
 	+ Darle menos tiempo al jugador;
 	+ Hacer que los fantasmas no aparezcan tan seguido;
-	+ Hacer que los fantasmas sean más pequeños.
+	+ Hacer que los fantasmas sean m√°s peque√±os.
 
-	Prueba tu juego algunas veces hasta que estés conforme con que tiene el nivel adecuado de dificultad.
+	Prueba tu juego algunas veces hasta que est√©s conforme con que tiene el nivel adecuado de dificultad.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Más objetos {.challenge}
-¿Puedes agregar otros objetos a tu juego?
+## Desaf√≠o: M√°s objetos {.challenge}
+¬øPuedes agregar otros objetos a tu juego?
 
 ![screenshot](ghost-final.png)
 
 Necesitas pensar sobre los objetos que agregas. Piensa acerca de:
 
-+ ¿Qué tan grande es?
-+ ¿Aparecerá más o menos seguido que los fantasmas?
-+ ¿Cómo se verá/sonará cuando sea atrapado?
-+ ¿Cuántos puntos te dará (o quitará) si lo atrapas?
++ ¬øQu√© tan grande es?
++ ¬øAparecer√° m√°s o menos seguido que los fantasmas?
++ ¬øC√≥mo se ver√°/sonar√° cuando sea atrapado?
++ ¬øCu√°ntos puntos te dar√° (o quitar√°) si lo atrapas?
 
-¡Si necesitas ayuda para agregar otro objeto, puedes volver a usar los pasos anteriores!
+¬°Si necesitas ayuda para agregar otro objeto, puedes volver a usar los pasos anteriores!
 
 ## Guarda tu proyecto { .save }

--- a/es-ES/Scratch 1/Lost in Space/Lost in Space.md
+++ b/es-ES/Scratch 1/Lost in Space/Lost in Space.md
@@ -4,66 +4,66 @@ level: Scratch 1
 language: es-ES
 stylesheet: scratch
 embeds: "*.png"
-materials: ["Recursos para el líder del Club /*.*"]
+materials: ["Recursos para el l√≠der del Club /*.*"]
 ...
 
-# Introducción { .intro }
+# Introducci√≥n { .intro }
 
-¡Vas a aprender a programar tu propia animación!
+¬°Vas a aprender a programar tu propia animaci√≥n!
 
 <div class="scratch-preview">
   <iframe allowtransparency="true" width="485" height="402" src="http://scratch.mit.edu/projects/embed/26818098/?autostart=false" frameborder="0"></iframe>
   <img src="space-final.png">
 </div>
 
-# Primer paso: Animación de una nave espacial { .activity .new-page}
+# Primer paso: Animaci√≥n de una nave espacial { .activity .new-page}
 
-¡Hagamos una nave espacial que vuele hacia la Tierra!
+¬°Hagamos una nave espacial que vuele hacia la Tierra!
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Comienza un nuevo proyecto Scratch, y elimina el objeto gato para que tu proyecto esté vacío. Puedes encontrar el editor de Scratch en línea en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
++ Comienza un nuevo proyecto Scratch, y elimina el objeto gato para que tu proyecto est√© vac√≠o. Puedes encontrar el editor de Scratch en l√≠nea en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
 
-+ Agrega los objetos “Nave especial” y “Tierra” al escenario. También deberías agregar las “Estrellas” en el fondo de tu escenario. Tu escenario debería verse así:
++ Agrega los objetos ‚ÄúNave especial‚Äù y ‚ÄúTierra‚Äù al escenario. Tambi√©n deber√≠as agregar las ‚ÄúEstrellas‚Äù en el fondo de tu escenario. Tu escenario deber√≠a verse as√≠:
 
 	![screenshot](space-sprites.png)
 
-+ Haz clic en tu nuevo objeto nave especial, y haz clic en la lengüeta “Disfraces”.
++ Haz clic en tu nuevo objeto nave especial, y haz clic en la leng√ºeta ‚ÄúDisfraces‚Äù.
 
 	![screenshot](space-costume.png)
 
-+ Usa la herramienta de flechas para seleccionar la imagen. Luego haz clic en la manija rotatoria circular, y haz rotar la imagen hasta que esté de costado.
++ Usa la herramienta de flechas para seleccionar la imagen. Luego haz clic en la manija rotatoria circular, y haz rotar la imagen hasta que est√© de costado.
 
 	![screenshot](space-rotate.png)
 
-+ Agrega este código a tu objeto nave espacial:
++ Agrega este c√≥digo a tu objeto nave espacial:
 
 	![screenshot](space-animate.png)
 
-	Cambia los números en los bloques de código, para que el código sea exactamente igual que en la imagen anterior.
+	Cambia los n√∫meros en los bloques de c√≥digo, para que el c√≥digo sea exactamente igual que en la imagen anterior.
 
-+ Si haces clic en los bloques de código para ejecutar el código, deberías ver que la nave especial habla, dobla y se mueve hacia el centro del escenario.
++ Si haces clic en los bloques de c√≥digo para ejecutar el c√≥digo, deber√≠as ver que la nave especial habla, dobla y se mueve hacia el centro del escenario.
 
 	![screenshot](space-animate-stage.png)
 
-	La posición de la pantalla `x:(0) y:(0)` {.blockmotion} es el centro del escenario. Una posición como `x:(-150) y:(-150)` {.blockmotion} está hacia la parte inferior izquierda del esenario, y una posición como `x:(150) y:(150)` {.blockmotion} está cerca de la parte superior derecha.
+	La posici√≥n de la pantalla `x:(0) y:(0)` {.blockmotion} es el centro del escenario. Una posici√≥n como `x:(-150) y:(-150)` {.blockmotion} est√° hacia la parte inferior izquierda del esenario, y una posici√≥n como `x:(150) y:(150)` {.blockmotion} est√° cerca de la parte superior derecha.
 
 	![screenshot](space-xy.png)
 
-	Si necesitas saber las coordinadas de una posición en el scenario, mueve el ratón a la posición para la cual deseas saber las coordinadas, que se despliegan abajo del escenario.
+	Si necesitas saber las coordinadas de una posici√≥n en el scenario, mueve el rat√≥n a la posici√≥n para la cual deseas saber las coordinadas, que se despliegan abajo del escenario.
 
 	![screenshot](space-coordinates.png)
 
-+ Prueba tu animación haciendo clic en la bandera verde justo arriba del escenario.
++ Prueba tu animaci√≥n haciendo clic en la bandera verde justo arriba del escenario.
 
 	![screenshot](space-flag.png)
 
-## Desafío: Mejora tu animación {.challenge}
-Puedes cambiar los números en el código de tu animación, para que:
-+ ¿La nave especial se mueva hasta tocar la Tierra?
-+ ¿La nave espacial se mueva más lentamente hacia la Tierra?
+## Desaf√≠o: Mejora tu animaci√≥n {.challenge}
+Puedes cambiar los n√∫meros en el c√≥digo de tu animaci√≥n, para que:
++ ¬øLa nave especial se mueva hasta tocar la Tierra?
++ ¬øLa nave espacial se mueva m√°s lentamente hacia la Tierra?
 
-Necesitarás cambiar los números en este bloque:
+Necesitar√°s cambiar los n√∫meros en este bloque:
 
 ```blocks
 	deslizar en (1) segs a x:(0) y:(0)
@@ -71,59 +71,59 @@ Necesitarás cambiar los números en este bloque:
 
 ## Guarda tu proyecto { .save }
 
-# Segundo paso: Animación mediante el uso de loops { .activity .new-page }
+# Segundo paso: Animaci√≥n mediante el uso de loops { .activity .new-page }
 
-Otra manera de animar la nave espacial es decirle que se mueva distancias pequeñas, muchas veces.
+Otra manera de animar la nave espacial es decirle que se mueva distancias peque√±as, muchas veces.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Elimina el bloque `deslizar` {.blockmotion} de tu código haciendo clic con el botón derecho y haciendo clic en “eliminar”. También puedes eliminar código arrastrándolo del área de secuencia de comandos, de nuevo al área de los bloques de código.
++ Elimina el bloque `deslizar` {.blockmotion} de tu c√≥digo haciendo clic con el bot√≥n derecho y haciendo clic en ‚Äúeliminar‚Äù. Tambi√©n puedes eliminar c√≥digo arrastr√°ndolo del √°rea de secuencia de comandos, de nuevo al √°rea de los bloques de c√≥digo.
 
 	![screenshot](space-delete-glide.png)
 
-+ Una vez que hayas eliminado tu código, agrega este código en su lugar:
++ Una vez que hayas eliminado tu c√≥digo, agrega este c√≥digo en su lugar:
 
 	![screenshot](space-loop.png)
 
-	El bloque `repetir` {.blockcontrol} se usa para repetir algo muchas veces, y también se conoce como un __loop__.
+	El bloque `repetir` {.blockcontrol} se usa para repetir algo muchas veces, y tambi√©n se conoce como un __loop__.
 
-+ Si haces clic en la bandera para probar este nuevo código, verás que hace casi lo mismo que antes.
++ Si haces clic en la bandera para probar este nuevo c√≥digo, ver√°s que hace casi lo mismo que antes.
 
-+ Puedes agregar más código a tu loop, para hacer cosas interesantes. Agrega el bloque `cambiar efecto de color por 25` {.blocklooks} en el loop (de la sección “Vistas”), para cambiar el color de la nave espacial repetidamente a medida que se mueve:
++ Puedes agregar m√°s c√≥digo a tu loop, para hacer cosas interesantes. Agrega el bloque `cambiar efecto de color por 25` {.blocklooks} en el loop (de la secci√≥n ‚ÄúVistas‚Äù), para cambiar el color de la nave espacial repetidamente a medida que se mueve:
 
 	![screenshot](space-colour.png)
 
-+ Haz clic en la bandera para ver tu nueva animación.
++ Haz clic en la bandera para ver tu nueva animaci√≥n.
 
 	![screenshot](space-colour-test.png)
 
-+ También puedes hacer que tu nave especial se haga más pequeña a medida que se mueve hacia la Tierra.
++ Tambi√©n puedes hacer que tu nave especial se haga m√°s peque√±a a medida que se mueve hacia la Tierra.
 
 	![screenshot](space-size.png)
 
-+ Prueba tu animación. ¿Qué sucede si haces clic en la bandera una segunda vez? ¿Tu nave espacial empieza con el tamaño correcto? Puedes usar este bloque para fijar tu animación:
++ Prueba tu animaci√≥n. ¬øQu√© sucede si haces clic en la bandera una segunda vez? ¬øTu nave espacial empieza con el tama√±o correcto? Puedes usar este bloque para fijar tu animaci√≥n:
 
 	```scratch
-	fijar tamaño a (100) %
+	fijar tama√±o a (100) %
 	```
 
 ## Guarda tu proyecto { .save }
 
 # Tercer paso: Mono que flota { .activity .new-page }
 
-Agreguemos un mono a tu animación, que está ¡perdido en el espacio!! 
+Agreguemos un mono a tu animaci√≥n, que est√° ¬°perdido en el espacio!!
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
 + Comienza agregando un objeto mono de la biblioteca.
 
 	![screenshot](space-monkey.png)
 
-+ Si haces clic en tu nuevo objeto mono y luego en “Disfraces”, puedes editar cómo se ve el mono. Haz clic en la herramienta “Elipse” y dibuja un casco espacial blanco alrededor de la cabeza del mono.
++ Si haces clic en tu nuevo objeto mono y luego en ‚ÄúDisfraces‚Äù, puedes editar c√≥mo se ve el mono. Haz clic en la herramienta ‚ÄúElipse‚Äù y dibuja un casco espacial blanco alrededor de la cabeza del mono.
 
 	![screenshot](space-monkey-edit.png)
 
-+ Ahora haz clic en “Secuancia de comandos”, y agrega este código a tu mono, para que gire lentamente en un círculo por siempre:
++ Ahora haz clic en ‚ÄúSecuancia de comandos‚Äù, y agrega este c√≥digo a tu mono, para que gire lentamente en un c√≠rculo por siempre:
 
 	```blocks
 		al presionar bandera verde
@@ -135,21 +135,21 @@ Agreguemos un mono a tu animación, que está ¡perdido en el espacio!!
 
 	El bloque `por siempre` {.blockcontrol} es otro loop, pero esta vez uno que nunca termina.
 
-+ Haz clic en la bandera para probar tu mono. Tendrás que hacer clic en el botón parar (al lado de la bandera) para terminar esta animación.
++ Haz clic en la bandera para probar tu mono. Tendr√°s que hacer clic en el bot√≥n parar (al lado de la bandera) para terminar esta animaci√≥n.
 
 	![screenshot](space-monkey-loop.png)
 
 # Cuarto paso: Asteroides que rebotan { .activity .new-page }
 
-Agreguemos a tu animación algunas rocas espaciales que flotan.
+Agreguemos a tu animaci√≥n algunas rocas espaciales que flotan.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Agrega un objeto “roca” a tu animación.
++ Agrega un objeto ‚Äúroca‚Äù a tu animaci√≥n.
 
 	![screenshot](space-rock-sprite.png)
 
-+ Agrega este código a tu roca, para hacer que rebote por todo el escenario:
++ Agrega este c√≥digo a tu roca, para hacer que rebote por todo el escenario:
 
 	```scratch
 	al presionar bandera verde
@@ -160,30 +160,30 @@ Agreguemos a tu animación algunas rocas espaciales que flotan.
 		if on edge, bounce
 	```
 
-+ Haz clic en la bandera para probar tu roca. ¿Rebota por todo el escenario?
++ Haz clic en la bandera para probar tu roca. ¬øRebota por todo el escenario?
 
 # Quinto paso: Estrellas que brillan { .activity .new-page }
 
 Combinemos loops para hacer una estrella que brilla.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Agrega un objeto “Estrella” a tu animación
++ Agrega un objeto ‚ÄúEstrella‚Äù a tu animaci√≥n
 
 	![screenshot](space-star-sprite.png)
 
-+ Agrega este código a tu estrella:
++ Agrega este c√≥digo a tu estrella:
 
 	![screenshot](space-star.png)
 
-+ Haz clic en la bandera para probar esta animación de la estrella. ¿Qué hace este código? Bien, la estrella se hace un poquito más grande 20 veces, y luego se hace un poquito más pequeña 20 veces, hasta llegar a su tamaño original. Estos 2 loops están dentro de un loop `por siempre` {.blockcontrol}, para que la animación se continúe repitiendo.
++ Haz clic en la bandera para probar esta animaci√≥n de la estrella. ¬øQu√© hace este c√≥digo? Bien, la estrella se hace un poquito m√°s grande 20 veces, y luego se hace un poquito m√°s peque√±a 20 veces, hasta llegar a su tama√±o original. Estos 2 loops est√°n dentro de un loop `por siempre` {.blockcontrol}, para que la animaci√≥n se contin√∫e repitiendo.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Crea tu propia animación {.challenge}
-Detén tu animación especial, haz clic en “Archivo” y luego en “Nuevo”, para comenzar un nuevo proyecto.
+## Desaf√≠o: Crea tu propia animaci√≥n {.challenge}
+Det√©n tu animaci√≥n especial, haz clic en ‚ÄúArchivo‚Äù y luego en ‚ÄúNuevo‚Äù, para comenzar un nuevo proyecto.
 
-Usa lo que aprendiste en este proyecto para crear tu propia animación. Puede ser cualquier cosa que quieras, pero trata de que la animación concuerde con el escenario. Aquí te damos algunos ejemplos:
+Usa lo que aprendiste en este proyecto para crear tu propia animaci√≥n. Puede ser cualquier cosa que quieras, pero trata de que la animaci√≥n concuerde con el escenario. Aqu√≠ te damos algunos ejemplos:
 
 ![screenshot](space-egs.png)
 

--- a/es-ES/Scratch 1/Paint Box/Paint Box.md
+++ b/es-ES/Scratch 1/Paint Box/Paint Box.md
@@ -1,42 +1,42 @@
 ---
-title: Caja de lápices
+title: Caja de l√°pices
 level: Scratch 1
 language: es-ES
 stylesheet: scratch
 embeds: "*.png"
-materiales: ["Recursos para el líder del Club /*.*","Recursos del Proyecto /*.*"]
+materiales: ["Recursos para el l√≠der del Club /*.*","Recursos del Proyecto /*.*"]
 ...
 
-# Introducción { .intro }
+# Introducci√≥n { .intro }
 
-¡En este Proyecto, vas a crear tu propio programa para pintar!
+¬°En este Proyecto, vas a crear tu propio programa para pintar!
 
 <div class="scratch-preview">
   <iframe allowtransparency="true" width="485" height="402" src="http://scratch.mit.edu/projects/embed/63473366/?autostart=false" frameborder="0"></iframe>
   <img src="paint-final.png">
 </div>
 
-# Primer paso: Crear un lápiz { .activity }
+# Primer paso: Crear un l√°piz { .activity }
 
-Comencemos por crear un lápiz, que puedes usar para dibujar en el escenario.
+Comencemos por crear un l√°piz, que puedes usar para dibujar en el escenario.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Comienza un nuevo proyecto Scratch, y elimina el objeto gato para que tu proyecto esté vacío. Puedes encontrar el editor de Scratch en línea en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
++ Comienza un nuevo proyecto Scratch, y elimina el objeto gato para que tu proyecto est√© vac√≠o. Puedes encontrar el editor de Scratch en l√≠nea en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
 
-+ Agrega el objeto lápiz a tu proyecto.
++ Agrega el objeto l√°piz a tu proyecto.
 
-	![screenshot](paint-pencil.png) 
+	![screenshot](paint-pencil.png)
 
-+ Haz clic en “Disfraces”, y elimina el disfraz “pencil-b”.
++ Haz clic en ‚ÄúDisfraces‚Äù, y elimina el disfraz ‚Äúpencil-b‚Äù.
 
-	![screenshot](paint-pencil-delete.png) 
+	![screenshot](paint-pencil-delete.png)
 
-+ Renombra tu disfraz “lápiz-azul”, y usa la herramienta “Colorear una forma” para hacer que el lápiz sea azul. 
++ Renombra tu disfraz ‚Äúl√°piz-azul‚Äù, y usa la herramienta ‚ÄúColorear una forma‚Äù para hacer que el l√°piz sea azul.
 
-	![screenshot](paint-pencil-blue.png) 
+	![screenshot](paint-pencil-blue.png)
 
-+ Como vas a estar usando tu ratón para dibujar, querrás que tu lápiz siga al ratón “por siempre” {.blockcontrol}. Agrega este código a tu objeto lápiz:
++ Como vas a estar usando tu rat√≥n para dibujar, querr√°s que tu l√°piz siga al rat√≥n ‚Äúpor siempre‚Äù {.blockcontrol}. Agrega este c√≥digo a tu objeto l√°piz:
 
 	```blocks
 		al presionar bandera verde
@@ -45,103 +45,103 @@ Comencemos por crear un lápiz, que puedes usar para dibujar en el escenario.
 		fin
 	```
 
-+ Prueba el código haciendo clic en la bandera y luego moviendo el ratón en el escenario. ¿Hace lo que esperabas que hiciera? 
++ Prueba el c√≥digo haciendo clic en la bandera y luego moviendo el rat√≥n en el escenario. ¬øHace lo que esperabas que hiciera?
 
-+ ¿Te has dado cuenta de que es el centro del lápiz y no la punta, lo que sigue al apuntador del ratón?
++ ¬øTe has dado cuenta de que es el centro del l√°piz y no la punta, lo que sigue al apuntador del rat√≥n?
 
 	![screenshot](paint-center.png)
 
-	Para solucionarlo, haz clic en el disfraz “lápiz-azul” de tu objeto lápiz, y haz clic en “Establecer centro del disfraz”.
+	Para solucionarlo, haz clic en el disfraz ‚Äúl√°piz-azul‚Äù de tu objeto l√°piz, y haz clic en ‚ÄúEstablecer centro del disfraz‚Äù.
 
 	![screenshot](paint-center-icon.png)
 
-+ Deberías ver que aparece una cruz en el disfraz. Ahora puedes hacer clic justo debajo de la punta del lápiz, y establecerla esta punta como el centro del disfraz.
++ Deber√≠as ver que aparece una cruz en el disfraz. Ahora puedes hacer clic justo debajo de la punta del l√°piz, y establecerla esta punta como el centro del disfraz.
 
 	![screenshot](paint-pencil-center.png)
 
-+ Haz clic en la lengüeta “Secuencias de comandos”, y luego prueba tu lápiz una vez más. ¿Funciona mejor que antes?
++ Haz clic en la leng√ºeta ‚ÄúSecuencias de comandos‚Äù, y luego prueba tu l√°piz una vez m√°s. ¬øFunciona mejor que antes?
 
-+ Ahora hagamos que tu lápiz dibuje `si` {.blockcontrol} se ha hecho clic en el ratón. Agrega este código a tu objeto lápiz:
++ Ahora hagamos que tu l√°piz dibuje `si` {.blockcontrol} se ha hecho clic en el rat√≥n. Agrega este c√≥digo a tu objeto l√°piz:
 
-	![screenshot](paint-pencil-draw-code.png)	
+	![screenshot](paint-pencil-draw-code.png)
 
-+ Prueba tu código una vez más. Esta vez, mueve el lápiz por el escenario y mantén apretado el botón del ratón. ¿Puedes dibujar con el lápiz?
++ Prueba tu c√≥digo una vez m√°s. Esta vez, mueve el l√°piz por el escenario y mant√©n apretado el bot√≥n del rat√≥n. ¬øPuedes dibujar con el l√°piz?
 
 	![screenshot](paint-draw.png)
 
 ## Guarda tu proyecto { .save }
 
-# Segundo paso: Lápices de colores { .activity }
+# Segundo paso: L√°pices de colores { .activity }
 
-¡Agreguemos distintos lápices de colores a tu proyecto, y permitámosle al usuario que pueda elegir entre ellos!
+¬°Agreguemos distintos l√°pices de colores a tu proyecto, y permit√°mosle al usuario que pueda elegir entre ellos!
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Haz clic en tu objeto lápiz, haz clic en “disfraces” y duplica tu disfraz “lápiz-azul”.
++ Haz clic en tu objeto l√°piz, haz clic en ‚Äúdisfraces‚Äù y duplica tu disfraz ‚Äúl√°piz-azul‚Äù.
 
 	![screenshot](paint-blue-duplicate.png)
 
-+ Renombra tu nuevo disfraz “lápiz-verde”, y pinta el lápiz de color verde.
++ Renombra tu nuevo disfraz ‚Äúl√°piz-verde‚Äù, y pinta el l√°piz de color verde.
 
 	![screenshot](paint-pencil-green.png)
 
-+ Crea dos objetos nuevos, que usarás para seleccionar el lápiz azul o verde.
++ Crea dos objetos nuevos, que usar√°s para seleccionar el l√°piz azul o verde.
 
 	![screenshot](paint-selectors.png)
 
-+ Cuando se hace clic en el selector verde, necesitas `enviar` {.blockevents} un mensaje al objeto lápiz, diciéndole que tiene que cambiar su disfraz y color de lápiz.
++ Cuando se hace clic en el selector verde, necesitas `enviar` {.blockevents} un mensaje al objeto l√°piz, dici√©ndole que tiene que cambiar su disfraz y color de l√°piz.
 
-	Para hacerlo, primero agrega este código a tu ícono selector verde:
+	Para hacerlo, primero agrega este c√≥digo a tu √≠cono selector verde:
 
 	```blocks
 		al hacer clic en este objeto
 		enviar [green v]
 	```
 
-	Para crear el bloque `enviar` {.blockevents}, haz clic en la flecha hacia abajo y selecciona “nuevo mensaje…”.
+	Para crear el bloque `enviar` {.blockevents}, haz clic en la flecha hacia abajo y selecciona ‚Äúnuevo mensaje‚Ä¶‚Äù.
 
 	![screenshot](paint-broadcast.png)
 
-	Luego puedes escribir “verde” para crear to nuevo mensaje.
+	Luego puedes escribir ‚Äúverde‚Äù para crear to nuevo mensaje.
 
 	![screenshot](paint-green-message.png)
 
-+ Ahora necesitas decirle a tu objeto lápiz qué tiene que hacer cuando recibe el mensaje. Agrega este código a tu objeto lápiz:
++ Ahora necesitas decirle a tu objeto l√°piz qu√© tiene que hacer cuando recibe el mensaje. Agrega este c√≥digo a tu objeto l√°piz:
 
 	```blocks
 		al recibir [green v]
 		cambiar disfraz a [pencil-green v]
-		fijar color de lápiz a [#00ff00]
+		fijar color de l√°piz a [#00ff00]
 	```
 
-	Para fijar el color de lápiz a verde, haz clic en la caja con colores en el bloque `fijar color` {.blockpen}, y haz clic en el ícono selector verde para elegir verde como el color para tu lápiz.
+	Para fijar el color de l√°piz a verde, haz clic en la caja con colores en el bloque `fijar color` {.blockpen}, y haz clic en el √≠cono selector verde para elegir verde como el color para tu l√°piz.
 
-+ Ahora puedes hacer lo mismo para el lápiz azul, agregando este código al objeto selector azul:
++ Ahora puedes hacer lo mismo para el l√°piz azul, agregando este c√≥digo al objeto selector azul:
 
 	```blocks
 		al hacer clic en este objeto
 		enviar [blue v]
 	```
 
-	...y agrega este código al objeto lápiz:
+	...y agrega este c√≥digo al objeto l√°piz:
 
 	```blocks
 		al recibir [blue v]
 		cambiar disfraz a [pencil-blue v]
-		fijar color de lápiz a [#0000ff]
+		fijar color de l√°piz a [#0000ff]
 	```
 
-+ Por último, necesitas decirle a tu objeto lápiz qué disfraz y color de lápiz elegir, y limpiar la pantalla cuando comienza tu proyecto. Agrega este código al comienzo del código de tu lápiz {.blockevents} `cuando se hace clic en la bandera `  (antes de `por siempre` {.blockcontrol} loop):
++ Por √∫ltimo, necesitas decirle a tu objeto l√°piz qu√© disfraz y color de l√°piz elegir, y limpiar la pantalla cuando comienza tu proyecto. Agrega este c√≥digo al comienzo del c√≥digo de tu l√°piz {.blockevents} `cuando se hace clic en la bandera `  (antes de `por siempre` {.blockcontrol} loop):
 
 	```blocks
 		borrar
 		cambiar disfraz a [blue-pencil v]
-		fijar color de lápiz a [#0000ff]
+		fijar color de l√°piz a [#0000ff]
 	```
 
-	¡Si lo prefieres, puedes comenzar con un color de lápiz diferente!
+	¬°Si lo prefieres, puedes comenzar con un color de l√°piz diferente!
 
-+ Prueba tu proyecto. ¿Puedes cambiar entre los lápices azul y verde?
++ Prueba tu proyecto. ¬øPuedes cambiar entre los l√°pices azul y verde?
 
 	![screenshot](paint-pens-test.png)
 
@@ -149,83 +149,83 @@ Comencemos por crear un lápiz, que puedes usar para dibujar en el escenario.
 
 # Tercer paso: Cuando se cometen errores { .activity .new-page }
 
-¡A veces se comenten errores, entonces agreguemos un botón “limpiar” y una goma a nuestro proyecto!
+¬°A veces se comenten errores, entonces agreguemos un bot√≥n ‚Äúlimpiar‚Äù y una goma a nuestro proyecto!
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Agreguemos un botón para limpiar el escenario. Para hacerlo, agrega el objeto letra 'X-block' al escenario, y píntalo de rojo.
++ Agreguemos un bot√≥n para limpiar el escenario. Para hacerlo, agrega el objeto letra 'X-block' al escenario, y p√≠ntalo de rojo.
 
 	![screenshot](paint-x.png)
 
-+ Agrega código a tu nuevo botón cancelar para limpiar el escenario cuando se le hace clic.
++ Agrega c√≥digo a tu nuevo bot√≥n cancelar para limpiar el escenario cuando se le hace clic.
 
 	```blocks
 		al hacer clic en este objeto
 		borrar
 	```
 
-	¡Fíjate que no necesitas enviar un mensaje para limpiar el escenario, ya que cualquier objeto puede hacerlo!
+	¬°F√≠jate que no necesitas enviar un mensaje para limpiar el escenario, ya que cualquier objeto puede hacerlo!
 
-+ También puedes crear una goma. Si tu líder del club te dio una carpeta de “Recursos”, haz clic en “Cargar disfraz desde archivo” y agrega la imagen “eraser.svg”.
++ Tambi√©n puedes crear una goma. Si tu l√≠der del club te dio una carpeta de ‚ÄúRecursos‚Äù, haz clic en ‚ÄúCargar disfraz desde archivo‚Äù y agrega la imagen ‚Äúeraser.svg‚Äù.
 
 	![screenshot](paint-eraser-costume.png)
-	
-	¡Si no tienes la imagen eraser.svg, crea en su lugar un nuevo lápiz blanco!
 
-+ También deberías agregar la imagen goma como un nuevo objeto selector. Así es como debería verse:
+	¬°Si no tienes la imagen eraser.svg, crea en su lugar un nuevo l√°piz blanco!
+
++ Tambi√©n deber√≠as agregar la imagen goma como un nuevo objeto selector. As√≠ es como deber√≠a verse:
 
 	![screenshot](paint-eraser-stage.png)
 
-+ Luego puedes agregar código al objeto selector goma, para decirle al lápiz que cambie a goma.
++ Luego puedes agregar c√≥digo al objeto selector goma, para decirle al l√°piz que cambie a goma.
 
 	```blocks
 		al hacer clic en este objeto
 		enviar [eraser v]
 	```
 
-+ ¡Cuando el lápiz recibe este mensaje, puedes crear una goma cambiando el disfraz del lápiz al de goma, y cambiando el color del lápiz al mismo color del escenario!
++ ¬°Cuando el l√°piz recibe este mensaje, puedes crear una goma cambiando el disfraz del l√°piz al de goma, y cambiando el color del l√°piz al mismo color del escenario!
 
 	```blocks
 		al recibir [eraser v]
 		cambiar disfraz a [eraser v]
-		fijar color de lápiz a [#FFFFFF]
+		fijar color de l√°piz a [#FFFFFF]
 	```
 
 + Prueba tu proyecto para ver si puedes limpiar y borrar en el escenario.
 
 	![screenshot](paint-erase-test.png)
 
-+ Hay otro problema más con el lápiz – puedes dibujar en cualquier parte del escenario, ¡incluso cerca de los íconos selectores!
++ Hay otro problema m√°s con el l√°piz ‚Äì puedes dibujar en cualquier parte del escenario, ¬°incluso cerca de los √≠conos selectores!
 
 	![screenshot](paint-draw-problem.png)
 
-	Para arreglar esto, tienes que decirle al lápiz que solo dibuje si se hace clic en el ratón _y_ si la posición y del ratón es mayor a -110 (`mouse y`{.blocksensing}`> -120` {.blockoperators}). Cambia la declaración `si` {.blockcontrol} de tu lápiz para que se vea así:
+	Para arreglar esto, tienes que decirle al l√°piz que solo dibuje si se hace clic en el rat√≥n _y_ si la posici√≥n y del rat√≥n es mayor a -110 (`mouse y`{.blocksensing}`> -120` {.blockoperators}). Cambia la declaraci√≥n `si` {.blockcontrol} de tu l√°piz para que se vea as√≠:
 
 	![screenshot](pencil-gt-code.png)
 
-+ Prueba tu proyecto. Ahora no deberías poder dibujar cerca de los bloques selectores.
++ Prueba tu proyecto. Ahora no deber√≠as poder dibujar cerca de los bloques selectores.
 
 	![screenshot](paint-fixed.png)
 
 ## Guarda tu proyecto { .save }
 
-# Cuarto paso: Cambiar el ancho del lápiz { .activity .new-page }
+# Cuarto paso: Cambiar el ancho del l√°piz { .activity .new-page }
 
-Permitámosle al usuario que pueda dibujar eligiendo distintos tamaños de lápices.
+Permit√°mosle al usuario que pueda dibujar eligiendo distintos tama√±os de l√°pices.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Primero, agrega una nueva variable que se llame “ancho”. Si no estás seguro sobre como hacerlo, el Proyecto “Globos” puede ayudarte.
++ Primero, agrega una nueva variable que se llame ‚Äúancho‚Äù. Si no est√°s seguro sobre como hacerlo, el Proyecto ‚ÄúGlobos‚Äù puede ayudarte.
 
-+ Agrega esta línea_dentro_del loop del código `por siempre` {.blockcontrol} de tu lápiz:
++ Agrega esta l√≠nea_dentro_del loop del c√≥digo `por siempre` {.blockcontrol} de tu l√°piz:
 
 	```blocks
-		fijar tamaño de lápiz a (width)
+		fijar tama√±o de l√°piz a (width)
 	```
 
-	El ancho de tu lápiz ahora se fijará repetidamente al valor de tu variable “ancho”.
+	El ancho de tu l√°piz ahora se fijar√° repetidamente al valor de tu variable ‚Äúancho‚Äù.
 
-+ Puedes cambiar el número almacenado en esta variable haciendo clic en el botón derecho sobre tu variable (en el escenario) y haciendo clic en la “barra deslizable”.
++ Puedes cambiar el n√∫mero almacenado en esta variable haciendo clic en el bot√≥n derecho sobre tu variable (en el escenario) y haciendo clic en la ‚Äúbarra deslizable‚Äù.
 
 	![screenshot](paint-slider.png)
 
@@ -233,33 +233,33 @@ Permitámosle al usuario que pueda dibujar eligiendo distintos tamaños de lápices
 
 	![screenshot](paint-slider-change.png)
 
-+ Prueba tu proyecto, y fíjate si puedes modificar el ancho de tu lápiz.
++ Prueba tu proyecto, y f√≠jate si puedes modificar el ancho de tu l√°piz.
 
 	![screenshot](paint-width-test.png)
 
-	Si lo deseas, puedes fijar el valor mínimo y máximo del “ancho” permitido. Para hacerlo, haz clic con el botón derecho sobre tu variable y luego haz clic de nuevo en “fijar min y max para la barra deslizable”. Fija los valores mínimos y máximos para tu variable a algo un poco más coherente, como 1 y 20.
+	Si lo deseas, puedes fijar el valor m√≠nimo y m√°ximo del ‚Äúancho‚Äù permitido. Para hacerlo, haz clic con el bot√≥n derecho sobre tu variable y luego haz clic de nuevo en ‚Äúfijar min y max para la barra deslizable‚Äù. Fija los valores m√≠nimos y m√°ximos para tu variable a algo un poco m√°s coherente, como 1 y 20.
 
 	![screenshot](paint-slider-max.png)
 
-	Continúa probando tu variable “ancho” hasta que estés conforme.
+	Contin√∫a probando tu variable ‚Äúancho‚Äù hasta que est√©s conforme.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Accesos directos { .challenge }
-¿Puedes crear accesos directos en el teclado para tus comandos? Por ejemplo:
+## Desaf√≠o: Accesos directos { .challenge }
+¬øPuedes crear accesos directos en el teclado para tus comandos? Por ejemplo:
 
-+ a = Cambiar al lápiz azul
-+ v = cambiar al lápiz verde
++ a = Cambiar al l√°piz azul
++ v = cambiar al l√°piz verde
 + g = cambiar a la goma
 + l = limpiar pantalla
 
-¡Incluso podrías permitirle al usuario cambiar el ancho del lápiz con las teclas de flechas!
+¬°Incluso podr√≠as permitirle al usuario cambiar el ancho del l√°piz con las teclas de flechas!
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Más lápices { .challenge }
-¡Puedes agregar lápices de color rojo, amarillo y negro a tu programa para pintar? Encontrarás todas las imágenes que necesitas en la carpeta “Recursos”. ¡Recuerda agregar los accesos rápidos en el teclado para estos nuevos lápices!
+## Desaf√≠o: M√°s l√°pices { .challenge }
+¬°Puedes agregar l√°pices de color rojo, amarillo y negro a tu programa para pintar? Encontrar√°s todas las im√°genes que necesitas en la carpeta ‚ÄúRecursos‚Äù. ¬°Recuerda agregar los accesos r√°pidos en el teclado para estos nuevos l√°pices!
 
-¿Puedes usar tus lápices para hacer un dibujo?
+¬øPuedes usar tus l√°pices para hacer un dibujo?
 
 ![screenshot](paint-final.png)

--- a/es-ES/Scratch 1/Rock Band/Rock Band.md
+++ b/es-ES/Scratch 1/Rock Band/Rock Band.md
@@ -4,47 +4,47 @@ level: Scratch 1
 language: es-ES
 stylesheet: scratch
 embeds: "*.png"
-materials: ["Recursos para el líder del Club /*.*","Recursos del Proyecto /*.*"]
+materials: ["Recursos para el l√≠der del Club /*.*","Recursos del Proyecto /*.*"]
 ...
 
-# Introducción { .intro }
+# Introducci√≥n { .intro }
 
-Vas a aprender cómo crear un juego en el cual usarás el ratón para navegar tu bote a una isla desierta.
+Vas a aprender c√≥mo crear un juego en el cual usar√°s el rat√≥n para navegar tu bote a una isla desierta.
 
 <div class="scratch-preview">
   <iframe allowtransparency="true" width="485" height="402" src="http://scratch.mit.edu/projects/embed/63957956/?autostart=false" frameborder="0"></iframe>
   <img src="boat-final.png">
 </div>
 
-# Primer paso: Cómo planificar el juego { .activity }
+# Primer paso: C√≥mo planificar el juego { .activity }
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto esté vacío. Puedes encontrar el editor en línea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
++ Comienza un nuevo proyecto Scratch, y borra el objeto gato para que tu proyecto est√© vac√≠o. Puedes encontrar el editor en l√≠nea de Scratch en <a href="http://jumpto.cc/scratch-new">jumpto.cc/scratch-new</a>.
 
-+ Haz clic en el fondo de tu escenario y planifica tu nivel. Deberías agregar:
++ Haz clic en el fondo de tu escenario y planifica tu nivel. Deber√≠as agregar:
 	+ Madera que tu bote tiene que evitar;
 	+ Una isla desierta a la que tu bote tiene que llegar.
 
-	Tu juego podría verse algo así:
+	Tu juego podr√≠a verse algo as√≠:
 
-	![screenshot](boat-bg.png) 
+	![screenshot](boat-bg.png)
 
-# Segundo paso: Cómo controlar el bote { .activity }
+# Segundo paso: C√≥mo controlar el bote { .activity }
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Si el líder de tu club te dio una carpeta de 'Recursos', haz clic en 'Cargar objeto del expediente' y agrega la imagen 'boat.png'. Deberías achicar el objeto y ubicarlo en la posición de comienzo.
++ Si el l√≠der de tu club te dio una carpeta de 'Recursos', haz clic en 'Cargar objeto del expediente' y agrega la imagen 'boat.png'. Deber√≠as achicar el objeto y ubicarlo en la posici√≥n de comienzo.
 
 	![screenshot](boat-boat.png)
 
-	Si no tienes la imagen boat.png, ¡puedes dibujar tu propio bote!
+	Si no tienes la imagen boat.png, ¬°puedes dibujar tu propio bote!
 
-+ Vas a controlar el bote con tu ratón. Agrega este código a tu bote:
++ Vas a controlar el bote con tu rat√≥n. Agrega este c√≥digo a tu bote:
 
 	```blocks
 		al presionar la bandera verde
-		apuntar en dirección (0 v)
+		apuntar en direcci√≥n (0 v)
 		ir a x: (-190) y: (-150)
 		por siempre
 			apuntar hacia [puntero del mouse v]
@@ -52,58 +52,58 @@ Vas a aprender cómo crear un juego en el cual usarás el ratón para navegar tu bo
 		fin
 	```
 
-+ Prueba tu bote haciendo clic en la bandera y moviendo el ratón. ¿Navega el bote hacia el ratón?
++ Prueba tu bote haciendo clic en la bandera y moviendo el rat√≥n. ¬øNavega el bote hacia el rat√≥n?
 
 	![screenshot](boat-mouse.png)
 
-+ ¿Qué sucede si el bote llega al apuntador del ratón?
++ ¬øQu√© sucede si el bote llega al apuntador del rat√≥n?
 
-	Para que esto no suceda, necesitarás agregar un bloque 'si'{.blockcontrol} a tu código, para que el bote solo se mueva si está a más de 5 píxeles del ratón.
+	Para que esto no suceda, necesitar√°s agregar un bloque 'si'{.blockcontrol} a tu c√≥digo, para que el bote solo se mueva si est√° a m√°s de 5 p√≠xeles del rat√≥n.
 
-	![screenshot](boat-pointer.png)	
+	![screenshot](boat-pointer.png)
 
-+ Prueba tu bote una vez más para ver si el problema ha sido resuelto.
++ Prueba tu bote una vez m√°s para ver si el problema ha sido resuelto.
 
 ## Guarda tu proyecto { .save }
 
-# Tercer paso: ¡Choques! { .activity .new-page }
+# Tercer paso: ¬°Choques! { .activity .new-page }
 
-¡Tu bote puede navegar a través de barreras de madera! Arreglemos eso.
+¬°Tu bote puede navegar a trav√©s de barreras de madera! Arreglemos eso.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Necesitarás 2 disfraces para tu bote, uno normal y otro para cuando el bote choca. Duplica el disfraz de tu bote y nómbralos 'normal' y 'chocado'.
++ Necesitar√°s 2 disfraces para tu bote, uno normal y otro para cuando el bote choca. Duplica el disfraz de tu bote y n√≥mbralos 'normal' y 'chocado'.
 
 + Haz clic en tu disfraz 'chocado', y elige la herramienta 'Seleccionar' para tomar partecitas del bote y moverlas y rotarlas por todos lados. Haz que parezca que tu bote ha chocado.
 
 	![screenshot](boat-hit-costume.png)
 
-+ Agrega este código a tu bote, dentro del loop `por siempre` {.blockcontrol}, para que choque cuando toca cualquier trocito de madera marrón:
++ Agrega este c√≥digo a tu bote, dentro del loop `por siempre` {.blockcontrol}, para que choque cuando toca cualquier trocito de madera marr√≥n:
 
 	```blocks
 		si <tocando el color [#603C15]?> entonces
 			cambiar disfraz a [hit v]
 			decir [Noooooo!] por (1) segundos
 			cambiar disfraz a [normal v]
-			apuntar en dirección (0 v)
+			apuntar en direcci√≥n (0 v)
 			ir a x: (-215) y: (-160)
 		fin
 	```
 
-	Este código está dentro del loop `por siempre` {.blockcontrol}, para que tu código constantemente verifique si tu bote ha chocado.
+	Este c√≥digo est√° dentro del loop `por siempre` {.blockcontrol}, para que tu c√≥digo constantemente verifique si tu bote ha chocado.
 
-+ También deberías asegurarte de que al comienzo tu bote siempre se vea 'normal'.
++ Tambi√©n deber√≠as asegurarte de que al comienzo tu bote siempre se vea 'normal'.
 
-+ Ahora si tratas de navegar a través de una barrera de madera, deberías ver que tu bote choca y vuelve al inicio.
++ Ahora si tratas de navegar a trav√©s de una barrera de madera, deber√≠as ver que tu bote choca y vuelve al inicio.
 
 	![screenshot](boat-crash.png)
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Ganar! {.challenge}
-¿Puedes agregar otra declaración `si` {.blockcontrol} al código de tu bote, para que el jugador gane cuando llegue a la isla desierta?
+## Desaf√≠o: ¬°Ganar! {.challenge}
+¬øPuedes agregar otra declaraci√≥n `si` {.blockcontrol} al c√≥digo de tu bote, para que el jugador gane cuando llegue a la isla desierta?
 
-Cuando el bote llega a la isla desierta amarilla, debería decir 'YEAH!' y el juego debería terminar. Tendrás que usar este código:
+Cuando el bote llega a la isla desierta amarilla, deber√≠a decir 'YEAH!' y el juego deber√≠a terminar. Tendr√°s que usar este c√≥digo:
 
 ```bloques
 	decir [YEAH!] por (1) segundos
@@ -114,22 +114,22 @@ Cuando el bote llega a la isla desierta amarilla, debería decir 'YEAH!' y el jue
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: Efectos de sonido {.challenge}
-Puedes agregar efectos de sonido a tu juego para cuando el bote choca y para cuando llega a la isla al final del juego. Incluso puedes agregar música de fondo (si necesitas ayuda con esto mira el proyecto 'Banda de Rock' anterior).
+## Desaf√≠o: Efectos de sonido {.challenge}
+Puedes agregar efectos de sonido a tu juego para cuando el bote choca y para cuando llega a la isla al final del juego. Incluso puedes agregar m√∫sica de fondo (si necesitas ayuda con esto mira el proyecto 'Banda de Rock' anterior).
 
 ## Guarda tu proyecto { .save }
 
-# Cuarto paso: Prueba del cronómetro { .activity }
+# Cuarto paso: Prueba del cron√≥metro { .activity }
 
-Agreguemos a tu juego un crnómetro, para que el jugador tenga que llegar a la isla lo más rápido posible.
+Agreguemos a tu juego un crn√≥metro, para que el jugador tenga que llegar a la isla lo m√°s r√°pido posible.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Agrega a tu escenario una nueva variable que se llame `tiempo` {.blockdata}. También puedes cambiar cómo se ve tu nueva variable. Si necesitas ayuda, mira el proyecto "Globos".
++ Agrega a tu escenario una nueva variable que se llame `tiempo` {.blockdata}. Tambi√©n puedes cambiar c√≥mo se ve tu nueva variable. Si necesitas ayuda, mira el proyecto "Globos".
 
 	![screenshot](boat-variable.png)
 
-+ Agrega este código a tu __escenario__, para que el cronómetro cuente hasta que el bote llega a la isla desierta:
++ Agrega este c√≥digo a tu __escenario__, para que el cron√≥metro cuente hasta que el bote llega a la isla desierta:
 
 	```blocks
 		al presionar la bandera verde
@@ -140,23 +140,23 @@ Agreguemos a tu juego un crnómetro, para que el jugador tenga que llegar a la is
 		fin
 	```
 
-+ ¡Ya está! ¡Prueba tu juego para ver qué tan rápido puedes llegar a la isla desierta!
++ ¬°Ya est√°! ¬°Prueba tu juego para ver qu√© tan r√°pido puedes llegar a la isla desierta!
 
 	![screenshot](boat-variable-test.png)
 
 ## Guarda tu proyecto { .save }
 
-# Quinto paso: Obstáculos y fuentes de energía { .activity }
+# Quinto paso: Obst√°culos y fuentes de energ√≠a { .activity }
 
-Este juego es _demasiado_ fácil – agreguemos cosas para hacerlo más interesante.
+Este juego es _demasiado_ f√°cil ‚Äì agreguemos cosas para hacerlo m√°s interesante.
 
-## Lista de verificación de actividades { .check }
+## Lista de verificaci√≥n de actividades { .check }
 
-+ Primero agreguemos algunos "estímulos" a tu juego, que harán que el bote navegue más rápido. Edita el fondo de tu scenario y agrega algunas flechas blancas de energía.
++ Primero agreguemos algunos "est√≠mulos" a tu juego, que har√°n que el bote navegue m√°s r√°pido. Edita el fondo de tu scenario y agrega algunas flechas blancas de energ√≠a.
 
 	![screenshot](boat-boost.png)
 
-+ Ahora puedes agregar código al loop `por siempre` {.blockcontrol} de tu bote, para que se mueva 2 _pasos extra_ cada vez que toca una fuente de energía blanca.
++ Ahora puedes agregar c√≥digo al loop `por siempre` {.blockcontrol} de tu bote, para que se mueva 2 _pasos extra_ cada vez que toca una fuente de energ√≠a blanca.
 
 	```blocks
 		si <tocando el color [#FFFFFF]?> entonces
@@ -164,28 +164,28 @@ Este juego es _demasiado_ fácil – agreguemos cosas para hacerlo más interesante.
 		fin
 	```
 
-+ También puedes agregar una puerta giratoria, que tu bote tiene que evitar. Agrega un nuevo objeto que se llame 'puerta', y que se vea así:
++ Tambi√©n puedes agregar una puerta giratoria, que tu bote tiene que evitar. Agrega un nuevo objeto que se llame 'puerta', y que se vea as√≠:
 
 	![screenshot](boat-gate.png)
 
-	Asegúrate de que el color de la puerta sea igual al color de las otras barreras de madera.
+	Aseg√∫rate de que el color de la puerta sea igual al color de las otras barreras de madera.
 
 + Fija el centro del objeto puerta.
 
 	![screenshot](boat-center.png)
 
-+ Agrega código a tu puerta para hacerla que lentamente gire `por siempre` {.blockcontrol}.
++ Agrega c√≥digo a tu puerta para hacerla que lentamente gire `por siempre` {.blockcontrol}.
 
-+ Prueba tu juego. Ahora deberías tener una puerta giratoria que tienes que evitar.
++ Prueba tu juego. Ahora deber√≠as tener una puerta giratoria que tienes que evitar.
 
 	![screenshot](boat-gate-test.png)
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Más obstáculos! {.challenge .new-page}
-¿Puedes agregar más obstáculos a tu juego? Aquí te damos algunas ideas:
+## Desaf√≠o: ¬°M√°s obst√°culos! {.challenge .new-page}
+¬øPuedes agregar m√°s obst√°culos a tu juego? Aqu√≠ te damos algunas ideas:
 
-+ Podrías agregar cieno verde a tu scenario, lo que frena al jugador cuando lo toca. Para hacerlo puedes usar un bloque `espera` {.blockcontrol}:
++ Podr√≠as agregar cieno verde a tu scenario, lo que frena al jugador cuando lo toca. Para hacerlo puedes usar un bloque `espera` {.blockcontrol}:
 
 ```blocks
 	esperar (0.01) segundos
@@ -193,7 +193,7 @@ Este juego es _demasiado_ fácil – agreguemos cosas para hacerlo más interesante.
 
 ![screenshot](boat-algae.png)
 
-+ ¡Podrías agregar un objeto en movimiento, como un tronco o un tiburón!
++ ¬°Podr√≠as agregar un objeto en movimiento, como un tronco o un tibur√≥n!
 
 ![screenshot](boat-obstacles.png)
 
@@ -204,7 +204,7 @@ Estos bloques pueden ayudarte:
 	rebotar si toca un borde
 ````
 
-Si tu nuevo objeto no es marrón, tendrás que agregar esto al código de tu bote:
+Si tu nuevo objeto no es marr√≥n, tendr√°s que agregar esto al c√≥digo de tu bote:
 
 ```blocks
 	si <  <tocando el color [#603C15]?> o <tocando [shark v]?> > entonces
@@ -213,31 +213,31 @@ Si tu nuevo objeto no es marrón, tendrás que agregar esto al código de tu bote:
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Más botes! {.challenge .new-page}
-¿Puedes convertir tu juego en una carrera entre 2 jugadores?
+## Desaf√≠o: ¬°M√°s botes! {.challenge .new-page}
+¬øPuedes convertir tu juego en una carrera entre 2 jugadores?
 
-+ Duplica el bote, renómbralo 'Jugador 2' y cámbiale el color.
++ Duplica el bote, ren√≥mbralo 'Jugador 2' y c√°mbiale el color.
 
 ![screenshot](boat-p2.png)
 
-+ Cambia este código para cambiar la posición de comienzo del Jugador 2:
++ Cambia este c√≥digo para cambiar la posici√≥n de comienzo del Jugador 2:
 
 ```blocks
 	ir a x: (-190) y: (-150)
 ```
 
-+ Borra el código que usa el ratón para controlar el bote:
++ Borra el c√≥digo que usa el rat√≥n para controlar el bote:
 
 ```blocks
 	si < (distancia a [puntero del mouse v]) > [5] > entonces
-		apuntar hacia [apuntador del ratón v]
+		apuntar hacia [apuntador del rat√≥n v]
 		mover (1) pasos
 	fin
 ```
 
-...y reemplázalo con código para controlar el bote usando las teclas de flechas.
+...y reempl√°zalo con c√≥digo para controlar el bote usando las teclas de flechas.
 
-Este es el código que necesitas para mover el bote hacia adelante:
+Este es el c√≥digo que necesitas para mover el bote hacia adelante:
 
 ```blocks
 	si < tecla [flecha arriba v] presionada? > entonces
@@ -245,12 +245,12 @@ Este es el código que necesitas para mover el bote hacia adelante:
 	fin
 ```
 
-También necesitarás un código para `doblar` {.blockmotion} el bote cuando se presionan las teclas de flechas izquierda y derecha.
+Tambi√©n necesitar√°s un c√≥digo para `doblar` {.blockmotion} el bote cuando se presionan las teclas de flechas izquierda y derecha.
 
 ## Guarda tu proyecto { .save }
 
-## Desafío: ¡Más niveles! {.challenge .new-page}
-¿Puedes crear escenarios adicionales y permitirle al jugador que elija entre niveles?
+## Desaf√≠o: ¬°M√°s niveles! {.challenge .new-page}
+¬øPuedes crear escenarios adicionales y permitirle al jugador que elija entre niveles?
 
 ```blocks
 	al presionar la tecla [espacio v]


### PR DESCRIPTION
Refs codeclub/lesson_format#173 (hopefully fixes it, though I haven’t tested!)

### How to fix this problem

 * In sublime, I opened a broken file, then clicked File -> Reopen with Encoding and tried a variety of encodings to figure out which it had been saved with. Reopening with “Western (Mac Roman)” appeared to display the file correctly.
 * For each file, I opened in sublime, then clicked File -> Reopen with Encoding -> Western (Mac Roman)
 * I then clicked File -> Save with Encoding -> UTF8

`git diff` shows the errors / corrections:

![screen shot 2015-10-12 at 10 50 07](https://cloud.githubusercontent.com/assets/464193/10425369/10219454-70cf-11e5-9ee7-de42f67378b4.png)

### How to avoid this problem

Always ensure these files are Saved with Encoding UTF-8 (without BOM! I hate BOMs). This sublimetext setting may help:
```
"default_encoding": "UTF-8"
```